### PR TITLE
Syntax error fixes for Python 2.6 and encoding fixes

### DIFF
--- a/httpie/httpie.py
+++ b/httpie/httpie.py
@@ -163,22 +163,13 @@ def main():
 
     # Display the response.
     original = response.raw._original_response
-    
-    try:
-        decode_from = [
-            bit.split('=')[1] for bit in response.headers['content-type'].split(';')
-                if 'charset' in bit
-        ][0]
-    except IndexError:
-        decode_from = 'utf-8'
-    
     status_line, headers, body = (
         u'HTTP/{version} {status} {reason}'.format(
             version='.'.join(str(original.version)),
             status=original.status, reason=original.reason,
         ),
-        str(original.msg).decode(decode_from),
-        response.content.decode(decode_from) if response.content else u''
+        str(original.msg).decode('utf-8'),
+        response.content.decode('utf-8') if response.content else u''
     )
 
     if args.prettify and sys.stdout.isatty():


### PR DESCRIPTION
Hey

Just tried installing with Python 2.6.1 and ran into syntax errors:

```
$ pip install httpie
Downloading/unpacking httpie
  Downloading httpie-0.1.3.tar.gz
  Running setup.py egg_info for package httpie
    Traceback (most recent call last):
      File "<string>", line 14, in <module>
      File "/Users/alen/build/httpie/setup.py", line 2, in <module>
        from httpie import httpie
      File "httpie/httpie.py", line 39
        for sep in self.separators
          ^
    SyntaxError: invalid syntax
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 14, in <module>

  File "/Users/alen/build/httpie/setup.py", line 2, in <module>

    from httpie import httpie

  File "httpie/httpie.py", line 39

    for sep in self.separators

      ^

SyntaxError: invalid syntax

----------------------------------------
Command python setup.py egg_info failed with error code 1
Storing complete log in /Users/alen/.pip/pip.log
```

I converted the dict comprehensions to list comprehensions wrapped in a `dict()` call. 
