### PR TITLE
Try to load strings as JSON data

### DIFF
--- a/httpie/httpie.py
+++ b/httpie/httpie.py
@@ -125,6 +125,11 @@ def main():
     # JSON/Form content type.
     if args.json or (not args.form and data):
         if sys.stdin.isatty():
+            for key, value in data.items():
+                try:
+                    data[key] = json.loads(value)
+                except ValueError:
+                    pass
             data = json.dumps(data)
         if 'Content-Type' not in headers and (data or args.json):
             headers['Content-Type'] = TYPE_JSON


### PR DESCRIPTION
I'm trying to use httpie with our web app CKAN, and I want to post a nested JSON object to CKAN like this:

```
http --json POST 'http://127.0.0.1:5000/api/action/vocabulary_create' name=Genre tags='[{"name":"government-spending"}, {"name": "climate"}]' Authorization:e6bd1b0c-87a6-4200-ab20-ccc90e8351e9
```

The problem is that tags, which is meant to be a JSON object, gets posted to CKAN as a string.

If I write my data (both name and tags) as a JSON object in a file and pipe the file to httpie, then it works. In file foo:

```
{
  "name": "Genre",
  "tags": [{"name": "government-spending"}, {"name": "climate"}]
}
```

Then:

```
http POST 'http://127.0.0.1:5000/api/action/vocabulary_create' Authorization:e6bd1b0c-87a6-4200-ab20-ccc90e8351e9 < foo
```

My commit fixes the first case, but I'm not sure whether or not it's a good solution.
