### PR TITLE
Added argparse to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,4 @@ setup(name='httpie',version=httpie.__version__,
     license=httpie.__licence__,
     packages=['httpie'],
     entry_points={'console_scripts': ['http = httpie.httpie:main']},
-    install_requires=['requests>=0.10.4', 'Pygments>=1.4'])
+    install_requires=['requests>=0.10.4', 'Pygments>=1.4', 'argparse>=1.2.1'])


### PR DESCRIPTION
Hi,
httpie was missing one dependency - argparse. I added it to install_requires using newest version available at time of writing this.
