### PR TITLE
Changed -f to --form since the former doesn't appear to work any more

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Headers
    Arbitrary HTTP headers. The ``:`` character is used to separate a header's name from its value, e.g., ``X-API-Token:123``.
 
 Simple data items
-  Data items are included in the request body. Depending on the ``Content-Type``, they are automatically serialized as a JSON ``Object`` (default) or ``application/x-www-form-urlencoded`` (the ``-f`` flag). Data items use ``=`` as the separator, e.g., ``hello=world``.
+  Data items are included in the request body. Depending on the ``Content-Type``, they are automatically serialized as a JSON ``Object`` (default) or ``application/x-www-form-urlencoded`` (the ``--form`` flag). Data items use ``=`` as the separator, e.g., ``hello=world``.
 
 Raw JSON items
   This item type is needed when ``Content-Type`` is JSON and a field's value is a ``Boolean``, ``Number``,  nested ``Object`` or an ``Array``, because simple data items are always serialized as ``String``. E.g. ``pies:=[1,2,3]``.


### PR DESCRIPTION
Running http 0.1.6 it seems the -f has been changed to --form:

$ http
usage: http [-h] [--version] [--json | --form] [--traceback]
            [--pretty | --ugly] [--headers | --body] [--style STYLE]
            [--auth AUTH] [--verify VERIFY] [--proxy PROXY]
            [--allow-redirects] [--file PATH] [--timeout TIMEOUT]
            METHOD URL [items [items ...]]
http: error: too few arguments
