### PR TITLE
porting of httpie to python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dist
 httpie.egg-info
 build
 *.pyc
+*.*~
+*.bak

--- a/httpie/__init__.py
+++ b/httpie/__init__.py
@@ -2,6 +2,6 @@
 HTTPie - cURL for humans.
 
 """
-__author__ = 'Jakub Roztocil'
+__author__ = ['Jakub Roztocil', 'Jakub Misiorny']
 __version__ = '0.1.6'
 __licence__ = 'BSD'

--- a/httpie/__main__.py
+++ b/httpie/__main__.py
@@ -87,8 +87,8 @@ def main(args=None,
             version='.'.join(str(original.version)),
             status=original.status, reason=original.reason,
         ),
-        str(original.msg).decode(encoding),
-        response.content.decode(encoding) if response.content else u''
+        str(original.msg),
+        response.content if response.content else ''
     )
 
     if do_prettify:
@@ -105,10 +105,16 @@ def main(args=None,
     if args.print_headers:
         stdout.write(status_line.strip())
         stdout.write('\n')
-        stdout.write(headers.strip().encode('utf-8'))
+        #stdout.write(headers.strip().encode('utf-8'))
+        #all string are utf-8
+        stdout.write(headers.strip())
         stdout.write('\n\n')
     if args.print_body:
-        stdout.write(body.strip().encode('utf-8'))
+        #stdout.write(body.strip().encode('utf-8'))
+        if isinstance(body, str):
+            stdout.write(body.strip())
+        else:
+            stdout.write(body.strip().decode())
         stdout.write('\n')
 
 

--- a/httpie/pretty.py
+++ b/httpie/pretty.py
@@ -13,7 +13,7 @@ from .pygson import JSONLexer
 
 
 DEFAULT_STYLE = 'solarized'
-AVAILABLE_STYLES = [DEFAULT_STYLE] + STYLE_MAP.keys()
+AVAILABLE_STYLES = [DEFAULT_STYLE] + list(STYLE_MAP.keys())
 FORMATTER = (Terminal256Formatter
              if '256color' in os.environ.get('TERM', '')
              else TerminalFormatter)

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,7 @@ if sys.argv[-1] == 'test':
     os.system('python tests.py')
     sys.exit()
 
-
 requirements = ['requests>=0.10.4', 'Pygments>=1.4']
-if sys.version_info < (2, 7):
-    requirements.append('argparse>=1.2.1')
-
 
 setup(
     name='httpie',
@@ -22,7 +18,7 @@ setup(
     url='http://httpie.org/',
     download_url='https://github.com/jkbr/httpie',
     author=httpie.__author__,
-    author_email='jakub@roztocil.name',
+    author_email=['jakub@roztocil.name', 'kuba.misiorny@gmail.com'],
     license=httpie.__licence__,
     packages=['httpie'],
     entry_points={
@@ -34,12 +30,10 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        # TODO: Python 3
-        # 'Programming Language :: Python :: 3.1'
-        # 'Programming Language :: Python :: 3.2'
-        # 'Programming Language :: Python :: 3.3'
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.1'
+        'Programming Language :: Python :: 3.2'
+        'Programming Language :: Python :: 3.3'
         'Environment :: Console',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',

--- a/tests.py
+++ b/tests.py
@@ -1,7 +1,7 @@
 import sys
 import unittest
 import argparse
-from StringIO import StringIO
+from io import StringIO
 from httpie import __main__
 from httpie import cli
 
@@ -22,7 +22,7 @@ def http(*args, **kwargs):
 
 class BaseTest(unittest.TestCase):
 
-    if sys.version < (2, 7):
+    if sys.version_info < (2, 7):
         def assertIn(self, member, container, msg=None):
             self.assert_(member in container, msg)
 


### PR DESCRIPTION
Hi

I have ported the wonderful httpie to python3. That is my first try at porting to python3. So, obviously I was not sure how to do it in some places. 
All the test pass. I am not sure how it should be done. Do you release one version which supports both py2 and py3 (ugly, ugly!), or somehow there should be two version in the PPI? 
