### PR TITLE
Add support for Digest authentication

### DIFF
--- a/httpie/__main__.py
+++ b/httpie/__main__.py
@@ -133,6 +133,12 @@ def main(args=None,
 
     # Fire the request.
     try:
+        credentials = None
+        if args.auth and args.digest:
+            credentials = requests.auth.HTTPDigestAuth(args.auth.key, args.auth.value)
+        elif args.auth:
+            credentials = requests.auth.HTTPBasicAuth(args.auth.key, args.auth.value)
+
         response = requests.request(
             method=args.method.lower(),
             url=args.url if '://' in args.url else 'http://%s' % args.url,
@@ -140,7 +146,7 @@ def main(args=None,
             data=data,
             verify=True if args.verify == 'yes' else args.verify,
             timeout=args.timeout,
-            auth=(args.auth.key, args.auth.value) if args.auth else None,
+            auth=credentials,
             proxies=dict((p.key, p.value) for p in args.proxy),
             files=files,
             allow_redirects=args.allow_redirects,

--- a/httpie/cli.py
+++ b/httpie/cli.py
@@ -215,6 +215,11 @@ parser.add_argument(
     '--auth', '-a', help='username:password',
     type=KeyValueType(SEP_COMMON)
 )
+
+parser.add_argument(
+    '--digest', '-d', action='store_true', help=_('Use Digest authentication')
+)
+
 parser.add_argument(
     '--verify',
     help=_('''


### PR DESCRIPTION
This small patch adds support for digest authentication by adding a `-d` or `--digest` flag on top of the `--auth` flag.
