### PR TITLE
-j/--json sets Accept header

### DIFF
--- a/httpie/__main__.py
+++ b/httpie/__main__.py
@@ -124,6 +124,8 @@ def main(args=None,
 
     # JSON/Form content type.
     if args.json or (not args.form and data):
+        if args.method.lower() == 'get' and 'Accept' not in headers:
+            headers['Accept'] = 'application/json'
         if stdin_isatty:
             data = json.dumps(data)
         if not files and ('Content-Type' not in headers and (data or args.json)):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -94,6 +94,10 @@ class TestHTTPie(BaseTest):
     def test_json(self):
         response = http('POST', 'http://httpbin.org/post', 'foo=bar')
         self.assertIn('"foo": "bar"', response)
+        response2 = http('-j', 'GET', 'http://httpbin.org/headers')
+        self.assertIn('"Accept": "application/json"', response2)
+        response3 = http('-j', 'GET', 'http://httpbin.org/headers', 'Accept:application/xml')
+        self.assertIn('"Accept": "application/xml"', response3)
 
     def test_form(self):
         response = http('--form', 'POST', 'http://httpbin.org/post', 'foo=bar')


### PR DESCRIPTION
I saw that I wasn't the only one ([issue #27](https://github.com/jkbr/httpie/issues/27)) that wanted to have httpie automatically set Accept: application/json for -j get requests, so I wrote that in. I also added a few tests to check the behavior.
