### PR TITLE
Escaping separators

### DIFF
--- a/httpie/cli.py
+++ b/httpie/cli.py
@@ -36,14 +36,24 @@ class KeyValueType(object):
     """A type used with `argparse`."""
     def __init__(self, *separators):
         self.separators = separators
+        self.escapes = ['\\\\' + sep for sep in separators]
 
     def __call__(self, string):
         found = {}
+        found_escapes = []
+        for esc in self.escapes:
+            found_escapes += [m.span() for m in re.finditer(esc, string)]
         for sep in self.separators:
-            regex = '[^\\\\]' + sep
-            match = re.search(regex, string)
-            if match:
-                found[match.start() + 1] = sep
+            matches = re.finditer(sep, string)
+            for match in matches:
+                start, end = match.span()
+                inside_escape = False
+                for estart, eend in found_escapes:
+                    if start >= estart and end <= eend:
+                        inside_escape = True
+                        break
+                if not inside_escape:
+                    found[start] = sep
 
         if not found:
             #noinspection PyExceptionInherit

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -76,6 +76,13 @@ class TestItemParsing(BaseTest):
         })
         self.assertIn('bar@baz', files)
 
+    def test_escape_longsep(self):
+        headers, data, files = cli.parse_items([
+            self.kv('bob\\:==foo'),
+        ])
+        self.assertDictEqual(data, {
+            'bob:=': 'foo',
+        })
     
     def test_valid_items(self):
         headers, data, files = cli.parse_items([


### PR DESCRIPTION
I was able to fix #39 by allowing the user to escape a separator with a \. I had to rewrite the parsing logic to do so, but it still passes all tests. I've also included new tests to check the escaping logic. 
