### PR TITLE
ANSI color strings are now processed by colorama on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,7 @@ if sys.argv[-1] == 'test':
 requirements = [
     # Debian has only requests==0.10.1 and httpie.deb depends on that.
     'requests>=0.10.1',
-    'Pygments>=1.5',
-    'colorama>=0.2.4'
+    'Pygments>=1.5'
 ]
 if sys.version_info[:2] in ((2, 6), (3, 1)):
     # argparse has been added in Python 3.2 / 2.7


### PR DESCRIPTION
When I installed httpie, ANSI color strings were not processed on Windows. The output was full of those crappy color strings. When I changed the outputting of the response to a single print statement, I got a nice output. I haven't really ever written code with Python, so I'm not sure about all the consequences that this change has, but at least I haven't found any problems so far.
