### PR TITLE
Encode using cp850 in Windows and using utf-8 in other environments.

### DIFF
--- a/httpie/core.py
+++ b/httpie/core.py
@@ -2,6 +2,7 @@ import sys
 import json
 import requests
 from requests.compat import str
+from requests.compat import is_windows
 from .models import HTTPMessage, Environment
 from .output import OutputProcessor
 from . import cliparse
@@ -118,6 +119,10 @@ def main(args=sys.argv[1:], env=Environment()):
     args = cli.parser.parse_args(args=args, env=env)
     response = get_response(args)
     output = get_output(args, env, response)
-    output_bytes = output.encode('utf8')
-    f = getattr(env.stdout, 'buffer', env.stdout)
-    f.write(output_bytes)
+    encoding = 'cp850' if is_windows else 'utf8'
+    if sys.version_info[0] <= 2:
+        # Python 2 -> use unicode() function
+        print(unicode(output.encode(encoding, errors='replace'), encoding))
+    else:
+        # Python 3 -> use str() function
+        print(str(output.encode(encoding, errors='replace'), encoding))


### PR DESCRIPTION
I tried to google a bit about unicode support in Windows, and the results aren't too promising ones. Apparently the windows cmd.exe just doesn't have a good unicode support, and it seems that the situation won't get improved.

Some solutions suggest to use code page 65001 as an alias for UTF-8 in Windows. However, multiple sources linked to this issue thread, which says, that it is not wise to do so:
http://bugs.python.org/issue6058#msg120712

Only vialable solution that I found was this one. Basicly, because the cmd.exe native encoding is 'cp850', we just encode string in that, and replace all unknown characters with question marks.
http://stackoverflow.com/questions/11050292/prevent-encoding-errors-in-python#11050550

I know that this is not a perfect solution, but as far as I've now understood, that's pretty much the best we can have.

I've tested this solution with
Win7 + Python 3.2.2
Win8 + Python 2.7.3
Lubuntu 11.10 + 2.7.2
and it works on all of those. I used http://www.i18nguy.com/unicode-example.html as a test page. Lubuntu showed all characters as intended, and Windows showed all characters that it understood + others replaced with '?'.
