### PR TITLE
Fix --session for Windows (with a Requests patch)

### DIFF
--- a/httpie/sessions.py
+++ b/httpie/sessions.py
@@ -67,7 +67,10 @@ class Host(object):
 
     @property
     def path(self):
-        path = os.path.join(SESSIONS_DIR, self.name)
+        # Name will include ':' if a port is specified, which is invalid
+        # on windows. DNS does not allow '_' in a domain, or for it to end
+        # in a number (I think?)
+        path = os.path.join(SESSIONS_DIR, self.name.replace(':', '_'))
         try:
             os.makedirs(path, mode=0o700)
         except OSError as e:
@@ -110,9 +113,9 @@ class Session(dict):
 
     def save(self):
         self['__version__'] = __version__
-        with open(self.path, 'wb') as f:
+        with open(self.path, 'w') as f:
             json.dump(self, f, indent=4, sort_keys=True, ensure_ascii=True)
-            f.write(b'\n')
+            f.write('\n')
 
     def delete(self):
         try:


### PR DESCRIPTION
A few fixes to get `--session` running on my windows machine :). You might want a different replacement, maybe in case you want to support edge cases on non-compliant DNS, like NetBIOS?

At least when running on python 3.3.0b2, I also needed this patch to Requests, although the current python 3 docs at least (for python 3.2.3) for `http.cookiejar.CookieJar.extract_cookies()` claim they require `unverifiable`, not `is_unverifiable` on the passed request?

```
diff --git a/requests/cookies.py b/requests/cookies.py
index bd2d665..b2ee6be 100644
--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -51,6 +51,9 @@ class MockRequest(object):
         # unverifiable == redirected
         return bool(self._r.response.history)

+    # urllib.request doesn't have is_unverifiable?
+    unverifiable = is_unverifiable
+
     def has_header(self, name):
         return name in self._r.headers or name in self._new_headers

```
