### PR TITLE
Mention xsel as pbpaste equivalent.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -673,6 +673,8 @@ On OS X, you can send the contents of the clipboard with ``pbpaste``:
 
     $ pbpaste | http PUT example.com
 
+You can install and use ``xsel`` on operating systems that use Xorg.
+
 
 Passing data through ``stdin`` cannot be combined with data fields specified
 on the command line.


### PR DESCRIPTION
Hi, just a small change to advertise the pbpaste equivalent for Debian and other operating systems.

(Also testing the edit-in-github feature : )
