### PR TITLE
Fixed PyPy cookie updating issue

### DIFF
--- a/httpie/sessions.py
+++ b/httpie/sessions.py
@@ -152,10 +152,8 @@ class Session(BaseConfigDict):
         # http://docs.python.org/2/library/cookielib.html#cookie-objects
         stored_attrs = ['value', 'path', 'secure', 'expires']
         self['cookies'] = {}
-        for host in jar._cookies.values():
-            for path in host.values():
-                for name, cookie in path.items():
-                    self['cookies'][name] = dict(
+        for cookie in jar:
+            self['cookies'][cookie.name] = dict(
                         (attname, getattr(cookie, attname))
                         for attname in stored_attrs
                     )


### PR DESCRIPTION
Fixed PyPy failing tests issue.
**jar._cookies** order is not enforsed in any way, so we should not rely on that. Direct iteration through **cookiejar** gives us all cookies, always in correct order.
