### PR TITLE
Remove leading white space in the config file.

### DIFF
--- a/httpie/config.py
+++ b/httpie/config.py
@@ -73,7 +73,8 @@ class BaseConfigDict(dict):
             self['__meta__']['about'] = self.about
 
         with open(self.path, 'w') as f:
-            json.dump(self, f, indent=4, sort_keys=True, ensure_ascii=True)
+            json.dump(self, f, indent=4, sort_keys=True,
+                      ensure_ascii=True, separators=(',', ': '))
             f.write('\n')
 
     def delete(self):


### PR DESCRIPTION
`json.dumps` uses the seperator `', '` by default. So when indent mode is enabled extra white space is added after each comma. The [docs](http://docs.python.org/2/library/json.html) recommend using `separators=(',', ': ')` (Note under Basic Usage) to avoid this.

Before: (Extra whitespace after commas.   

```
cat ~/.httpie/config.json -A
{$
    "__meta__": {$
        "about": "HTTPie configuration file", $
        "help": "https://github.com/jkbr/httpie#config", $
        "httpie": "0.6.0"$
    }, $
    "default_options": [], $
    "implicit_content_type": "json"$
}$
```

Fixed: 

```
{$
    "__meta__": {$
        "about": "HTTPie configuration file",$
        "help": "https://github.com/jkbr/httpie#config",$
        "httpie": "0.6.0"$
    },$
    "default_options": [],$
    "implicit_content_type": "json"$
}$
```
