### PR TITLE
process XML data before pretty-printing to trim whitespace

### DIFF
--- a/httpie/output.py
+++ b/httpie/output.py
@@ -2,7 +2,7 @@
 
 """
 import json
-import xml.dom.minidom
+from xml.etree import ElementTree
 from functools import partial
 from itertools import chain
 
@@ -406,15 +406,33 @@ class XMLProcessor(BaseProcessor):
     """XML body processor."""
     # TODO: tests
 
+    # in-place prettyprint formatter
+    # c.f. http://effbot.org/zone/element-lib.htm#prettyprint
+    @staticmethod
+    def indent(elem, indent_text=' ' * DEFAULT_INDENT):
+        def _indent(elem, level=0):
+            i = "\n" + level * indent_text
+            if len(elem):
+                if not elem.text or not elem.text.strip():
+                    elem.text = i + indent_text
+                if not elem.tail or not elem.tail.strip():
+                    elem.tail = i
+                for elem in elem:
+                    _indent(elem, level + 1)
+                if not elem.tail or not elem.tail.strip():
+                    elem.tail = i
+            else:
+                if level and (not elem.tail or not elem.tail.strip()):
+                    elem.tail = i
+        return _indent(elem)
+
     def process_body(self, content, content_type, subtype, encoding):
         if subtype == 'xml':
             try:
-                # Pretty print the XML; pre-process content into clean string
-                raw_string = ''.join(
-                    (x.strip() for x in content.encode(encoding).split('\n')))
-                doc = xml.dom.minidom.parseString(raw_string)
-                content = doc.toprettyxml(indent=' ' * DEFAULT_INDENT)
-            except xml.parsers.expat.ExpatError:
+                root = ElementTree.fromstring(content.encode(encoding))
+                self.indent(root)
+                content = ElementTree.tostring(root)
+            except ElementTree.ParseError:
                 # Ignore invalid XML errors (skips attempting to pretty print)
                 pass
         return content


### PR DESCRIPTION
When receiving XML data that is already 'pretty' the current pretty printing process seems to add extra new line characters. I've modified the code to actually strip whitespace from the source input which seems to resolve this.

Input:

``` python
>>> raw = '<a>\n  <b>blah</b>\n  <c>123</c>\n</a>\n'
>>> print raw
<a>
  <b>blah</b>
  <c>123</c>
</a>
```

Current:

``` python

>>> print parseString(raw).toprettyxml(indent=' '*4)
<?xml version="1.0" ?>
<a>


    <b>
        blah
    </b>


    <c>
        123
    </c>


</a>
```

With patch:

``` python
>>> processed = ''.join((x.strip() for x in raw.split('\n')))
>>> print parseString(processed).toprettyxml(indent=' '*4)
<?xml version="1.0" ?>
<a>
    <b>
        blah
    </b>
    <c>
        123
    </c>
</a>
```
