### PR TITLE
fixes #185 changed from streaming to immediately downloading

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1257,6 +1257,7 @@ Changelog
     * Added ``field=@file.txt`` and ``field:=@file.json`` for embedding
       the contents of text and JSON files into request data.
     * Added curl-style shorthand for localhost
+    * Fixed the ``--timeout`` issue.
 * `0.7.1`_ (2013-09-24)
     * Added ``--ignore-stdin``.
     * Added support for auth plugins.

--- a/httpie/client.py
+++ b/httpie/client.py
@@ -74,7 +74,6 @@ def get_requests_kwargs(args):
         credentials = auth_plugin.get_auth(args.auth.key, args.auth.value)
 
     kwargs = {
-        'stream': True,
         'method': args.method.lower(),
         'url': args.url,
         'headers': args.headers,


### PR DESCRIPTION
Streaming caused the the timeout value to be ignored. I changed the behavior to immediately download the content instead.
