### PR TITLE
Expunge user:pass@... from Host header.

### DIFF
--- a/httpie/models.py
+++ b/httpie/models.py
@@ -155,7 +155,7 @@ class HTTPRequest(HTTPMessage):
         headers = dict(self._orig.headers)
 
         if 'Host' not in headers:
-            headers['Host'] = url.netloc
+            headers['Host'] = url.netloc.split('@')[-1]
 
         headers = ['%s: %s' % (name, value)
                    for name, value in headers.items()]


### PR DESCRIPTION
In verbose mode, the basic auth user and password would show up in colored
output reporting the Host header, as reported in https://github.com/jkbr/httpie/issues/169

Similar code is used at https://github.com/jkbr/httpie/blob/4fe3deb9d916023b3bffe60e0d655216bcb9276a/httpie/sessions.py#L35
