### PR TITLE
Add support for default request items in config file

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -30,3 +30,4 @@ Patches and ideas
 * `cido <https://github.com/cido>`_
 * `Justin Bonnar <https://github.com/jargonjustin>`_
 * `Nathan LaFreniere <https://github.com/nlf>`_
+* `Dionysis Grigoropoulos <https://github.com/Erethon>`_

--- a/httpie/config.py
+++ b/httpie/config.py
@@ -92,7 +92,8 @@ class Config(BaseConfigDict):
 
     DEFAULTS = {
         'implicit_content_type': 'json',
-        'default_options': []
+        'default_options': [],
+        'default_request_items': [],
     }
 
     def __init__(self, *args, **kwargs):

--- a/httpie/core.py
+++ b/httpie/core.py
@@ -64,6 +64,9 @@ def main(args=sys.argv[1:], env=Environment()):
     if env.config.default_options:
         args = env.config.default_options + args
 
+    if env.config.default_request_items:
+        args = args + env.config.default_request_items
+
     def error(msg, *args, **kwargs):
         msg = msg % args
         level = kwargs.get('level', 'error')


### PR DESCRIPTION
I searched through the open (and closed) Issues looking for a way to set a default "User-Agent" and other request items (Headers, URL parameters etc) and didn't find anything really useful. Closest thing I found was using the --session option [1](https://github.com/jkbr/httpie/issues/180), which I didn't try myself, but didn't look like a clean way to achieve what I wanted. Thus, I added a new option in config.json file, to support setting of default request items.

All tests completed successfully, except for "test_timeout_exit_status" for which there is an open bug report [2](https://github.com/jkbr/httpie/issues/185).
