### PR TITLE
Fixed the order of args to grep in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -756,7 +756,7 @@ Or the output of another program:
 
 .. code-block:: bash
 
-    $ grep /var/log/httpd/error_log '401 Unauthorized' | http POST example.org/intruders
+    $ grep '401 Unauthorized' /var/log/httpd/error_log | http POST example.org/intruders
 
 
 You can use ``echo`` for simple data:


### PR DESCRIPTION
I just had a tiny fix for the docs.  According to the grep man pages[0](http://unixhelp.ed.ac.uk/CGI/man-cgi?grep), the pattern to be searched for goes before the file it is to be searched for in.

Also, just wanted to say.  This is a very cool project, I can't wait to try it out.
