### PR TITLE
add dependant package 'colorama' to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ tests_require = [
 
 install_requires = [
     'requests>=2.3.0',
-    'Pygments>=1.5'
+    'Pygments>=1.5',
+    'colorama>=0.3.1'
 ]
 try:
     #noinspection PyUnresolvedReferences


### PR DESCRIPTION
I needed to run "pip install colorama" before httpie worked for me;  Python 2.7, windows
