### PR TITLE
Fallback to JSON highlighting if subtype contains json

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,3 +31,4 @@ Patches and ideas
 * `Justin Bonnar <https://github.com/jargonjustin>`_
 * `Nathan LaFreniere <https://github.com/nlf>`_
 * `Matthias Lehmann <https://github.com/matleh>`_
+* `Dennis Brakhane <https://github.com/brakhane>`_

--- a/httpie/output/formatters/colors.py
+++ b/httpie/output/formatters/colors.py
@@ -76,6 +76,10 @@ def get_lexer(mime):
             '%s/%s' % (type_, subtype_name),
             '%s/%s' % (type_, subtype_suffix)
         ])
+    # as a last resort, if no lexer feels responsible, and
+    # the subtype contains 'json', take the JSON lexer
+    if 'json' in subtype:
+        lexer_names.append('json')
     lexer = None
     for mime_type in mime_types:
         try:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -32,9 +32,13 @@ class TestColors:
         'application/json',
         'application/json+foo',
         'application/foo+json',
+        'application/json-foo',
+        'application/x-json',
         'foo/json',
         'foo/json+bar',
         'foo/bar+json',
+        'foo/json-foo',
+        'foo/x-json',
     ])
     def test_get_lexer(self, mime):
         lexer = get_lexer(mime)


### PR DESCRIPTION
Some JSON based formats like JSON Home Documents[1] don't
use a '+json' suffix, but simply contain json in their
MIME type. Also, some servers might use (outdated)
types like 'application/x-json'.

The JSON formatter can already handle those cases,
but the highlighter was ignoring them.

This commit will let the highlighter choose the JSON
lexer if no other lexer could be found and the MIME subtype
contains 'json'

[1] http://tools.ietf.org/html/draft-nottingham-json-home-03
