### PR TITLE
Fix Snap autocompletion

### DIFF
--- a/extras/httpie-completion.bash
+++ b/extras/httpie-completion.bash
@@ -7,7 +7,7 @@ _http_complete() {
     fi
 }
 
-complete -o default -F _http_complete http
+complete -o default -F _http_complete http httpie.http httpie.https https
 
 _http_complete_options() {
     local cur_word=$1

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -81,7 +81,7 @@ parts:
       python -m compileall -f $packages
 
       echo "Copying extra files ..."
-      cp $SNAPCRAFT_PART_SRC/extras/httpie-completion.bash $SNAPCRAFT_PRIME/bin/
+      cp $SNAPCRAFT_PART_SRC/extras/httpie-completion.bash $SNAPCRAFT_PRIME/
 
 plugs:
   dot-config-httpie:
@@ -102,13 +102,13 @@ apps:
       - home
       - network
       - removable-media
-    completer: bin/httpie-completion.bash
+    completer: httpie-completion.bash
     environment:
       LC_ALL: C.UTF-8
 
   https:
     command: bin/https
     plugs: *plugs
-    completer: bin/httpie-completion.bash
+    completer: httpie-completion.bash
     environment:
       LC_ALL: C.UTF-8


### PR DESCRIPTION
After placing the completion script in `$SNAPCRAFT_PRIME` it was working as expected
`httpie.http -`<kbd>TAB</kbd><kbd>TAB</kbd>
@BoboTiG can you please verify once.