### PR TITLE
Suggested fixes by iCR, OpenRefactory, Inc.

### DIFF
--- a/httpie/internal/update_warnings.py
+++ b/httpie/internal/update_warnings.py
@@ -41,7 +41,9 @@ def _fetch_updates(env: Environment) -> str:
     file = env.config.version_info_file
     data = _read_data_error_free(file)
 
-    response = requests.get(PACKAGE_INDEX_LINK, verify=False)
+    #OpenRefactoryWarning: The 'requests.get'method does not verify server certificat
+    # Certificate validation is essential to create secure SSL/TLS sessions not vulnerable to man-in-the-middle attacks.
+    response = requests.get(PACKAGE_INDEX_LINK, verify=True)
     response.raise_for_status()
 
     data.setdefault('last_warned_date', None)


### PR DESCRIPTION
This issue was detected in branch `master` of `httpie` project on the version with commit hash `810bb1`. This is an instance of a weak cryptography issue.

**Fixes for weak cryptography issues:**
In file: `update_warnings.py`, method: `_fetch_updates`, there is code that turns off certificate validation while establishing an `SSL/TLS` connection. According to [CWE 295, ](https://cwe.mitre.org/data/definitions/295.html)if a certificate is invalid or malicious, it might allow an attacker to spoof a trusted entity by interfering in the communication path between the host and client. **iCR** suggested that the certificate validation option should not be turned off.

This issue was detected by **OpenRefactory's Intelligent Code Repair (iCR)**. We are running **iCR** on libraries in the `PyPI` repository to identify issues and fix them. More info at: [pypi.openrefactory.com](https://pypi.openrefactory.com/)