### PR TITLE
Add HTTP/3 to mapping in property version (HTTPResponse)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [3.3.0-dev](https://github.com/httpie/httpie/compare/3.2.2...master) (unreleased)
 
 - Make it possible to [unset](https://httpie.io/docs/cli/default-request-headers) the `User-Agent`, `Accept-Encoding`, and `Host` request headers. ([#1502](https://github.com/httpie/httpie/issues/1502))
+- Add HTTP/3 version mapping into the HTTPResponse wrapper and rename HTTP/2.0 to HTTP/2. ([#1513](https://github.com/httpie/httpie/issues/1513))
 
 ## [3.2.2](https://github.com/httpie/httpie/compare/3.2.1...3.2.2) (2022-05-19)
 

--- a/httpie/models.py
+++ b/httpie/models.py
@@ -112,7 +112,8 @@ class HTTPResponse(HTTPMessage):
             9: '0.9',
             10: '1.0',
             11: '1.1',
-            20: '2.0',
+            20: '2',
+            30: '3',
         }
         fallback = 11
         version = None


### PR DESCRIPTION
Also, prefer HTTP/2 instead of HTTP/2.0

Help #1512

Note: pygment HTTPLexer support HTTP/2.0 and HTTP/2, but not HTTP/3.0 (only HTTP/3)
The correct thing to do is to support HTTP/2 short.