### PR TITLE
Remove unnecessary process wait on MacOS (issue #1523)

### DIFF
--- a/httpie/internal/daemons.py
+++ b/httpie/internal/daemons.py
@@ -87,10 +87,7 @@ def _spawn_posix(args: List[str], process_context: ProcessContext) -> None:
     if platform.system() == 'Darwin':
         # Double-fork is not reliable on MacOS, so we'll use a subprocess
         # to ensure the task is isolated properly.
-        process = _start_process(args, env=process_context)
-        # Unlike windows, since we already completed the fork procedure
-        # we can simply join the process and wait for it.
-        process.communicate()
+        _start_process(args, env=process_context)
     else:
         os.environ.update(process_context)
         with suppress(BaseException):

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,6 +1,5 @@
 """Utilities for HTTPie test suite."""
 import re
-import shlex
 import os
 import sys
 import time
@@ -205,15 +204,8 @@ class BaseCLIResponse:
     devnull: str = None
     json: dict = None
     exit_status: ExitStatus = None
-    command: str = None
     args: List[str] = []
     complete_args: List[str] = []
-
-    @property
-    def command(self):
-        cmd = ' '.join(shlex.quote(arg) for arg in ['http', *self.args])
-        # pytest-httpbin to real httpbin.
-        return re.sub(r'127\.0\.0\.1:\d+', 'httpbin.org', cmd)
 
     @classmethod
     def from_raw_data(self, data: Union[str, bytes]) -> 'BaseCLIResponse':
@@ -448,7 +440,6 @@ def http(
         if r.exit_status != ExitStatus.SUCCESS:
             sys.stderr.write(r.stderr)
 
-        # print(f'\n\n$ {r.command}\n')
         return r
 
     finally:


### PR DESCRIPTION
Remove `process.communicate()` in MacOS causing wait for subprocess even when the subprocess results were not used.