### PR TITLE
Update methods.yml to include cask flag per changes in homebrew for MacOS Homebrew install

### DIFF
--- a/docs/installation/methods.yml
+++ b/docs/installation/methods.yml
@@ -70,7 +70,7 @@ tools:
     commands:
       install:
         - brew update
-        - brew install httpie
+        - brew install httpie --cask
       upgrade:
         - brew update
         - brew upgrade httpie


### PR DESCRIPTION
Homebrew now requires the flag `--cask` to install correctly