### PR TITLE
Add codespell config, action (to only alert about new misspellings) + fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,5 @@
+[codespell]
+skip = .git,*.pdf,*.svg,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -2,4 +2,4 @@
 skip = .git,*.pdf,*.svg,.codespellrc
 check-hidden = true
 # ignore-regex = 
-# ignore-words-list =
+ignore-words-list = datas

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,22 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/docs/README.md
+++ b/docs/README.md
@@ -2103,7 +2103,7 @@ $ cat session.json
 ```
 
 ```bash
-# Re-use the existing session — the API-Token header will be set:
+# Reuse the existing session — the API-Token header will be set:
 $ http --session=./session.json pie.dev/headers
 ```
 
@@ -2410,7 +2410,7 @@ HTTPie offers extensibility through a [plugin API](https://github.com/httpie/cli
 and there are dozens of plugins available to try!
 They add things like new authentication methods ([akamai/httpie-edgegrid](https://github.com/akamai/httpie-edgegrid)),
 transport mechanisms ([httpie/httpie-unixsocket](https://github.com/httpie/httpie-unixsocket)),
-message convertors ([banteg/httpie-image](https://github.com/banteg/httpie-image)), or simply
+message converters ([banteg/httpie-image](https://github.com/banteg/httpie-image)), or simply
 change how a response is formatted.
 
 > Note: Plugins are usually made by our community members, and thus have no direct relationship with

--- a/extras/profiling/benchmarks.py
+++ b/extras/profiling/benchmarks.py
@@ -21,7 +21,7 @@ Examples:
     $ python extras/profiling/benchmarks.py --fast
 
     # For verify everything works as expected, pass --debug-single-value.
-    # It will only run everything once, so the resuls are not reliable. But
+    # It will only run everything once, so the results are not reliable. But
     # very useful when iterating on a benchmark
     $ python extras/profiling/benchmarks.py --debug-single-value
 


### PR DESCRIPTION
In the past they were fixed once in a while but not prevented, thus it is neat but not perfect as it would be after adding this action ;-)