### PR TITLE
Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -133,7 +133,7 @@ Also works for other Debian-derived distributions like MX Linux, Linux Mint, dee
 ```bash
 # Install httpie
 $ curl -SsL https://packages.httpie.io/deb/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/httpie.gpg
-$ sudo echo "deb [arch=amd64 signed-by=/usr/share/keyrings/httpie.gpg] https://packages.httpie.io/deb ./" > /etc/apt/sources.list.d/httpie.list
+$ sudo sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/httpie.gpg] https://packages.httpie.io/deb ./" > /etc/apt/sources.list.d/httpie.list'
 $ sudo apt update
 $ sudo apt install httpie
 ```


### PR DESCRIPTION
existing advice is broken, results in 'bash: /etc/apt/sources.list.d/httpie.list: Permission denied' because it is trying to redirect the output of the sudo command outside privileged context.  

Converted it to a subshell invocation