### PR TITLE
docs: replace redirection with tee command with sudo for file creation

### DIFF
--- a/docs/installation/methods.yml
+++ b/docs/installation/methods.yml
@@ -39,7 +39,7 @@ tools:
       install:
         - curl -SsL https://packages.httpie.io/deb/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/httpie.gpg
       # - curl -SsL -o /etc/apt/sources.list.d/httpie.list https://packages.httpie.io/deb/httpie.list
-        - sudo echo "deb [arch=amd64 signed-by=/usr/share/keyrings/httpie.gpg] https://packages.httpie.io/deb ./" > /etc/apt/sources.list.d/httpie.list
+        - echo "deb [arch=amd64 signed-by=/usr/share/keyrings/httpie.gpg] https://packages.httpie.io/deb ./" | sudo tee /etc/apt/sources.list.d/httpie.list > /dev/null
         - sudo apt update
         - sudo apt install httpie
       upgrade:


### PR DESCRIPTION

This pull request addresses an issue where using `sudo`-prefixed `echo` does not grant elevated permissions for the subsequent redirection operation, resulting in a failure to write files under `/etc/apt`.
By replacing the redirection with a `sudo`-prefixed `tee` command, this change ensures that files are written with root privileges, effectively resolving the permission issue. This modification is essential for operations requiring write access to protected directories.