### PR TITLE
Don't expire cookie with later setting in the same headers

### DIFF
--- a/httpie/utils.py
+++ b/httpie/utils.py
@@ -167,11 +167,14 @@ def get_expired_cookies(
         split_cookies(cookies)
     )
 
-    cookies = [
+    # Use a dict to keep only the last value for each cookie, so that an early
+    # expiration doesn't prevent a later setting in the same headers.
+    cookies = {
         # The first attr name is the cookie name.
-        dict(attrs[1:], name=attrs[0][0])
+        attrs[0][0]: dict(attrs[1:], name=attrs[0][0])
         for attrs in attr_sets
-    ]
+    }
+    cookies = list(cookies.values())
 
     _max_age_to_expires(cookies=cookies, now=now)
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -437,6 +437,15 @@ class TestExpiredCookies(CookieTestBase):
                 datetime(2020, 6, 11).timestamp(),
                 []
             ),
+            (
+                # Don't expire cookie with later setting.
+                (
+                    'session=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; secure; HttpOnly, '
+                    'session=bar; Path=/; secure; HttpOnly'
+                ),
+                None,
+                []
+            )
         ]
     )
     def test_get_expired_cookies_manages_multiple_cookie_headers(self, cookies, now, expected_expired):


### PR DESCRIPTION
I'm interacting with a server that likes to simultaneously expire a cookie and give it a new value in the same headers:

```
Set-Cookie: JSESSIONID=expire; Max-Age=0; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
Set-Cookie: JSESSIONID=ED0E0934E642AC44A7ACDE6CED16D904; Path=/; Secure; HttpOnly
```

This isn't spec, as I understand it, but it turns out the browsers don't care. They just use the last value given.

So this PR updates httpie to behave in the same way, by ignoring an earlier expiration in favor of a later setting in the same headers.