### PR TITLE
Explicitly load default certificates when creating SSL context (#1583)

### DIFF
--- a/httpie/ssl_.py
+++ b/httpie/ssl_.py
@@ -48,6 +48,13 @@ class HTTPieHTTPSAdapter(HTTPAdapter):
             ssl_version=ssl_version,
             ciphers=ciphers,
         )
+        # workaround for a bug in requests 2.32.3, see:
+        # https://github.com/httpie/cli/issues/1583
+        if getattr(self._ssl_context, 'load_default_certs', None) is not None:
+            # if load_default_certs is present, get_ca_certs must be
+            # also, no need for another getattr
+            if not self._ssl_context.get_ca_certs():
+                self._ssl_context.load_default_certs()
         super().__init__(**kwargs)
 
     def init_poolmanager(self, *args, **kwargs):

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     pip
     charset_normalizer>=2.0.0
     defusedxml>=0.6.0
-    requests[socks] >=2.22.0, <=2.31.0
+    requests[socks] >=2.22.0
     Pygments>=2.5.2
     requests-toolbelt>=0.9.1
     multidict>=4.7.0


### PR DESCRIPTION
Requests prior to 2.32.3 always loaded the default (system-wide) set of trusted certificates into custom SSL contexts. 2.32.3 no longer does. This has broken a lot of users, but the fix is moving slowly upstream due to security considerations - see https://github.com/psf/requests/issues/6730 and https://github.com/psf/requests/pull/6731 .

As suggested at https://github.com/psf/requests/pull/6710#issuecomment-2137802782 this can be worked around by explicitly loading the default certificates into the context. We check the method exists before calling it just to be safe, it was added in Python 3.4.

Also, drop the dependency pin as it's no longer needed with this workaround.