### PR TITLE
Added an alias for HTTPS in fish completions

### DIFF
--- a/extras/httpie-completion.fish
+++ b/extras/httpie-completion.fish
@@ -112,3 +112,10 @@ complete -c http      -l version           -d 'Show version'
 complete -c http      -l traceback         -d 'Prints exception traceback should one occur'
 complete -c http      -l default-scheme -x -d 'The default scheme to use'
 complete -c http      -l debug             -d 'Show debugging output'
+
+
+# Alias for https to http
+
+function https --wraps http
+        http $argv;
+end


### PR DESCRIPTION
Ensure that fish completion is working with the `https` command. 
It just wraps the identical completions from `http` to `https`.

[Documentation for fish-functions, see --wraps](https://fishshell.com/docs/current/cmds/function.html#description)
> Inherit completions from the given WRAPPED_COMMAND. See the documentation for complete for more information.