### PR TITLE
Fix `https` behaviour in fish

### DIFF
--- a/extras/httpie-completion.fish
+++ b/extras/httpie-completion.fish
@@ -116,6 +116,4 @@ complete -c http      -l debug             -d 'Show debugging output'
 
 # Alias for https to http
 
-function https --wraps http
-        http $argv;
-end
+complete -c https -w http


### PR DESCRIPTION
Using the name `https` to invoke HTTPie should make HTTPie default to the https:// scheme, but using a fish function to replace invocations of `https` with invocations of `http` defeats this behaviour. Instead, just tell fish to complete `https` in the same way as `http`.

See #1598