### PR TITLE
fix(download): respect Content-Length when Content-Encoding is present

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,6 @@ jobs:
           - '3.10'
           - '3.9'
           - '3.8'
-          - '3.7'
         pyopenssl: [0, 1]
     runs-on: ${{ matrix.os }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This document records all notable changes to [HTTPie](https://httpie.io).
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Fixed
+- Respect `Content-Length` with `--download` when `Content-Encoding` is present to avoid false "Incomplete download" errors. ([#423](https://github.com/httpie/cli/issues/423))
+
 ## [3.2.4](https://github.com/httpie/cli/compare/3.2.3...3.2.4) (2024-11-01)
 
 - Fix default certs loading and unpin `requests`. ([#1596](https://github.com/httpie/cli/issues/1596))

--- a/docs/download.md
+++ b/docs/download.md
@@ -1,0 +1,8 @@
+# Download mode
+
+HTTPie's `--download` option saves response bodies to files. When a server
+returns a `Content-Encoding` (for example `gzip`), the `Content-Length` header
+is treated as the size of the encoded payload as defined in RFC 9110 § 8.6.
+HTTPie writes the body exactly as received and no longer compares the header to
+the post-decompression size.
+

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1,18 +1,27 @@
+import gzip
 import os
 import tempfile
 import time
-import requests
 from unittest import mock
 from urllib.request import urlopen
 
 import pytest
+import requests
 from requests.structures import CaseInsensitiveDict
 
 from httpie.downloads import (
-    parse_content_range, filename_from_content_disposition, filename_from_url,
-    get_unique_filename, ContentRangeError, Downloader, PARTIAL_CONTENT
+    PARTIAL_CONTENT,
+    ContentRangeError,
+    Downloader,
+    filename_from_content_disposition,
+    filename_from_url,
+    get_unique_filename,
+    parse_content_range,
 )
-from .utils import http, MockEnvironment
+from httpie.status import ExitStatus
+from tests.utils.http_server import TestHandler
+
+from .utils import MockEnvironment, http
 
 
 class Response(requests.Response):
@@ -23,85 +32,95 @@ class Response(requests.Response):
         self.status_code = status_code
 
 
+@TestHandler.handler("GET", "/gzip")
+def gzip_handler(handler):
+    payload = b"Hello, world!"
+    compressed = gzip.compress(payload)
+    handler.send_response(200)
+    handler.send_header("Content-Length", str(len(compressed)))
+    handler.send_header("Content-Encoding", "gzip")
+    handler.end_headers()
+    handler.wfile.write(compressed)
+
+
 class TestDownloadUtils:
 
     def test_Content_Range_parsing(self):
         parse = parse_content_range
 
-        assert parse('bytes 100-199/200', 100) == 200
-        assert parse('bytes 100-199/*', 100) == 200
+        assert parse("bytes 100-199/200", 100) == 200
+        assert parse("bytes 100-199/*", 100) == 200
 
         # single byte
-        assert parse('bytes 100-100/*', 100) == 101
+        assert parse("bytes 100-100/*", 100) == 101
 
         # missing
         pytest.raises(ContentRangeError, parse, None, 100)
 
         # syntax error
-        pytest.raises(ContentRangeError, parse, 'beers 100-199/*', 100)
+        pytest.raises(ContentRangeError, parse, "beers 100-199/*", 100)
 
         # unexpected range
-        pytest.raises(ContentRangeError, parse, 'bytes 100-199/*', 99)
+        pytest.raises(ContentRangeError, parse, "bytes 100-199/*", 99)
 
         # invalid instance-length
-        pytest.raises(ContentRangeError, parse, 'bytes 100-199/199', 100)
+        pytest.raises(ContentRangeError, parse, "bytes 100-199/199", 100)
 
         # invalid byte-range-resp-spec
-        pytest.raises(ContentRangeError, parse, 'bytes 100-99/199', 100)
+        pytest.raises(ContentRangeError, parse, "bytes 100-99/199", 100)
 
-    @pytest.mark.parametrize('header, expected_filename', [
-        ('attachment; filename=hello-WORLD_123.txt', 'hello-WORLD_123.txt'),
-        ('attachment; filename=".hello-WORLD_123.txt"', 'hello-WORLD_123.txt'),
-        ('attachment; filename="white space.txt"', 'white space.txt'),
-        (r'attachment; filename="\"quotes\".txt"', '"quotes".txt'),
-        ('attachment; filename=/etc/hosts', 'hosts'),
-        ('attachment; filename=', None)
-    ])
+    @pytest.mark.parametrize(
+        "header, expected_filename",
+        [
+            ("attachment; filename=hello-WORLD_123.txt", "hello-WORLD_123.txt"),
+            ('attachment; filename=".hello-WORLD_123.txt"', "hello-WORLD_123.txt"),
+            ('attachment; filename="white space.txt"', "white space.txt"),
+            (r'attachment; filename="\"quotes\".txt"', '"quotes".txt'),
+            ("attachment; filename=/etc/hosts", "hosts"),
+            ("attachment; filename=", None),
+        ],
+    )
     def test_Content_Disposition_parsing(self, header, expected_filename):
         assert filename_from_content_disposition(header) == expected_filename
 
     def test_filename_from_url(self):
-        assert 'foo.txt' == filename_from_url(
-            url='http://example.org/foo',
-            content_type='text/plain'
+        assert "foo.txt" == filename_from_url(
+            url="http://example.org/foo", content_type="text/plain"
         )
-        assert 'foo.html' == filename_from_url(
-            url='http://example.org/foo',
-            content_type='text/html; charset=UTF-8'
+        assert "foo.html" == filename_from_url(
+            url="http://example.org/foo", content_type="text/html; charset=UTF-8"
         )
-        assert 'foo' == filename_from_url(
-            url='http://example.org/foo',
-            content_type=None
+        assert "foo" == filename_from_url(
+            url="http://example.org/foo", content_type=None
         )
-        assert 'foo' == filename_from_url(
-            url='http://example.org/foo',
-            content_type='x-foo/bar'
+        assert "foo" == filename_from_url(
+            url="http://example.org/foo", content_type="x-foo/bar"
         )
 
     @pytest.mark.parametrize(
-        'orig_name, unique_on_attempt, expected',
+        "orig_name, unique_on_attempt, expected",
         [
             # Simple
-            ('foo.bar', 0, 'foo.bar'),
-            ('foo.bar', 1, 'foo.bar-1'),
-            ('foo.bar', 10, 'foo.bar-10'),
+            ("foo.bar", 0, "foo.bar"),
+            ("foo.bar", 1, "foo.bar-1"),
+            ("foo.bar", 10, "foo.bar-10"),
             # Trim
-            ('A' * 20, 0, 'A' * 10),
-            ('A' * 20, 1, 'A' * 8 + '-1'),
-            ('A' * 20, 10, 'A' * 7 + '-10'),
+            ("A" * 20, 0, "A" * 10),
+            ("A" * 20, 1, "A" * 8 + "-1"),
+            ("A" * 20, 10, "A" * 7 + "-10"),
             # Trim before ext
-            ('A' * 20 + '.txt', 0, 'A' * 6 + '.txt'),
-            ('A' * 20 + '.txt', 1, 'A' * 4 + '.txt-1'),
+            ("A" * 20 + ".txt", 0, "A" * 6 + ".txt"),
+            ("A" * 20 + ".txt", 1, "A" * 4 + ".txt-1"),
             # Trim at the end
-            ('foo.' + 'A' * 20, 0, 'foo.' + 'A' * 6),
-            ('foo.' + 'A' * 20, 1, 'foo.' + 'A' * 4 + '-1'),
-            ('foo.' + 'A' * 20, 10, 'foo.' + 'A' * 3 + '-10'),
-        ]
+            ("foo." + "A" * 20, 0, "foo." + "A" * 6),
+            ("foo." + "A" * 20, 1, "foo." + "A" * 4 + "-1"),
+            ("foo." + "A" * 20, 10, "foo." + "A" * 3 + "-10"),
+        ],
     )
-    @mock.patch('httpie.downloads.get_filename_max_length')
-    def test_unique_filename(self, get_filename_max_length,
-                             orig_name, unique_on_attempt,
-                             expected):
+    @mock.patch("httpie.downloads.get_filename_max_length")
+    def test_unique_filename(
+        self, get_filename_max_length, orig_name, unique_on_attempt, expected
+    ):
 
         def attempts(unique_on_attempt=0):
             # noinspection PyUnresolvedReferences,PyUnusedLocal
@@ -123,39 +142,50 @@ class TestDownloadUtils:
 class TestDownloads:
 
     def test_actual_download(self, httpbin_both, httpbin):
-        robots_txt = '/robots.txt'
+        robots_txt = "/robots.txt"
         body = urlopen(httpbin + robots_txt).read().decode()
-        env = MockEnvironment(stdin_isatty=True, stdout_isatty=False, show_displays=True)
-        r = http('--download', httpbin_both.url + robots_txt, env=env)
-        assert 'Downloading' in r.stderr
+        env = MockEnvironment(
+            stdin_isatty=True, stdout_isatty=False, show_displays=True
+        )
+        r = http("--download", httpbin_both.url + robots_txt, env=env)
+        assert "Downloading" in r.stderr
         assert body == r
 
+    def test_download_with_gzip_content_encoding(self, http_server, tmp_path):
+        orig_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            r = http("--download", f"http://{http_server}/gzip")
+            assert r.exit_status == ExitStatus.SUCCESS
+            with open("gzip", "rb") as f:
+                assert gzip.decompress(f.read()) == b"Hello, world!"
+        finally:
+            os.chdir(orig_cwd)
+
     def test_download_with_Content_Length(self, mock_env, httpbin_both):
-        with open(os.devnull, 'w') as devnull:
+        with open(os.devnull, "w") as devnull:
             downloader = Downloader(mock_env, output_file=devnull)
             downloader.start(
-                initial_url='/',
+                initial_url="/",
                 final_response=Response(
-                    url=httpbin_both.url + '/',
-                    headers={'Content-Length': 10}
-                )
+                    url=httpbin_both.url + "/", headers={"Content-Length": 10}
+                ),
             )
             time.sleep(1.1)
-            downloader.chunk_downloaded(b'12345')
+            downloader.chunk_downloaded(b"12345")
             time.sleep(1.1)
-            downloader.chunk_downloaded(b'12345')
+            downloader.chunk_downloaded(b"12345")
             downloader.finish()
             assert not downloader.interrupted
 
     def test_download_no_Content_Length(self, mock_env, httpbin_both):
-        with open(os.devnull, 'w') as devnull:
+        with open(os.devnull, "w") as devnull:
             downloader = Downloader(mock_env, output_file=devnull)
             downloader.start(
-                final_response=Response(url=httpbin_both.url + '/'),
-                initial_url='/'
+                final_response=Response(url=httpbin_both.url + "/"), initial_url="/"
             )
             time.sleep(1.1)
-            downloader.chunk_downloaded(b'12345')
+            downloader.chunk_downloaded(b"12345")
             downloader.finish()
             assert not downloader.interrupted
 
@@ -164,98 +194,96 @@ class TestDownloads:
             orig_cwd = os.getcwd()
             os.chdir(tmp_dirname)
             try:
-                assert not os.path.isfile('filename.bin')
+                assert not os.path.isfile("filename.bin")
                 downloader = Downloader(mock_env)
                 downloader.start(
                     final_response=Response(
-                        url=httpbin_both.url + '/',
+                        url=httpbin_both.url + "/",
                         headers={
-                            'Content-Length': 5,
-                            'Content-Disposition': 'attachment; filename="filename.bin"',
-                        }
+                            "Content-Length": 5,
+                            "Content-Disposition": 'attachment; filename="filename.bin"',
+                        },
                     ),
-                    initial_url='/'
+                    initial_url="/",
                 )
-                downloader.chunk_downloaded(b'12345')
+                downloader.chunk_downloaded(b"12345")
                 downloader.finish()
                 downloader.failed()  # Stop the reporter
                 assert not downloader.interrupted
 
                 # TODO: Auto-close the file in that case?
                 downloader._output_file.close()
-                assert os.path.isfile('filename.bin')
+                assert os.path.isfile("filename.bin")
             finally:
                 os.chdir(orig_cwd)
 
     def test_download_interrupted(self, mock_env, httpbin_both):
-        with open(os.devnull, 'w') as devnull:
+        with open(os.devnull, "w") as devnull:
             downloader = Downloader(mock_env, output_file=devnull)
             downloader.start(
                 final_response=Response(
-                    url=httpbin_both.url + '/',
-                    headers={'Content-Length': 5}
+                    url=httpbin_both.url + "/", headers={"Content-Length": 5}
                 ),
-                initial_url='/'
+                initial_url="/",
             )
-            downloader.chunk_downloaded(b'1234')
+            downloader.chunk_downloaded(b"1234")
             downloader.finish()
             assert downloader.interrupted
 
     def test_download_resumed(self, mock_env, httpbin_both):
         with tempfile.TemporaryDirectory() as tmp_dirname:
-            file = os.path.join(tmp_dirname, 'file.bin')
-            with open(file, 'a'):
+            file = os.path.join(tmp_dirname, "file.bin")
+            with open(file, "a"):
                 pass
 
-            with open(file, 'a+b') as output_file:
+            with open(file, "a+b") as output_file:
                 # Start and interrupt the transfer after 3 bytes written
                 downloader = Downloader(mock_env, output_file=output_file)
                 downloader.start(
                     final_response=Response(
-                        url=httpbin_both.url + '/',
-                        headers={'Content-Length': 5}
+                        url=httpbin_both.url + "/", headers={"Content-Length": 5}
                     ),
-                    initial_url='/'
+                    initial_url="/",
                 )
-                downloader.chunk_downloaded(b'123')
+                downloader.chunk_downloaded(b"123")
                 downloader.finish()
                 downloader.failed()
                 assert downloader.interrupted
 
             # Write bytes
-            with open(file, 'wb') as fh:
-                fh.write(b'123')
+            with open(file, "wb") as fh:
+                fh.write(b"123")
 
-            with open(file, 'a+b') as output_file:
+            with open(file, "a+b") as output_file:
                 # Resume the transfer
                 downloader = Downloader(mock_env, output_file=output_file, resume=True)
 
                 # Ensure `pre_request()` is working as expected too
                 headers = {}
                 downloader.pre_request(headers)
-                assert headers['Accept-Encoding'] == 'identity'
-                assert headers['Range'] == 'bytes=3-'
+                assert headers["Accept-Encoding"] == "identity"
+                assert headers["Range"] == "bytes=3-"
 
                 downloader.start(
                     final_response=Response(
-                        url=httpbin_both.url + '/',
-                        headers={'Content-Length': 5, 'Content-Range': 'bytes 3-4/5'},
-                        status_code=PARTIAL_CONTENT
+                        url=httpbin_both.url + "/",
+                        headers={"Content-Length": 5, "Content-Range": "bytes 3-4/5"},
+                        status_code=PARTIAL_CONTENT,
                     ),
-                    initial_url='/'
+                    initial_url="/",
                 )
-                downloader.chunk_downloaded(b'45')
+                downloader.chunk_downloaded(b"45")
                 downloader.finish()
 
     def test_download_with_redirect_original_url_used_for_filename(self, httpbin):
         # Redirect from `/redirect/1` to `/get`.
-        expected_filename = '1.json'
+        expected_filename = "1.json"
         orig_cwd = os.getcwd()
         with tempfile.TemporaryDirectory() as tmp_dirname:
             os.chdir(tmp_dirname)
             try:
-                assert os.listdir('.') == []
-                http('--download', httpbin + '/redirect/1')
-                assert os.listdir('.') == [expected_filename]
+                assert os.listdir(".") == []
+                http("--download", httpbin + "/redirect/1")
+                assert os.listdir(".") == [expected_filename]
             finally:
                 os.chdir(orig_cwd)


### PR DESCRIPTION
Per RFC 9110 § 8.6 the Content-Length header reflects the **encoded** size. The previous logic compared it to the decoded size, yielding false "Incomplete download" errors for gzip responses.