### PR TITLE
Add tests for int and float JSON values and fix lexer regex

### DIFF
--- a/httpie/output/lexers/json.py
+++ b/httpie/output/lexers/json.py
@@ -21,7 +21,7 @@ class EnhancedJsonLexer(RegexLexer):
         'root': [
             # Eventual non-JSON data prefix followed by actual JSON body.
             (
-                fr'({PREFIX_REGEX})' + r'((?:[{\["]|true|false|null|-?\d).+)',
+                fr'({PREFIX_REGEX})' + r'((?:[{\["]|true|false|null|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?).*)',
                 bygroups(PREFIX_TOKEN, using(JsonLexer))
             ),
             # JSON body.

--- a/httpie/output/lexers/json.py
+++ b/httpie/output/lexers/json.py
@@ -20,9 +20,8 @@ class EnhancedJsonLexer(RegexLexer):
     tokens = {
         'root': [
             # Eventual non-JSON data prefix followed by actual JSON body.
-            # FIX: data prefix + number (integer or float) is not correctly handled.
             (
-                fr'({PREFIX_REGEX})' + r'((?:[{\["]|true|false|null).+)',
+                fr'({PREFIX_REGEX})' + r'((?:[{\["]|true|false|null|-?\d).+)',
                 bygroups(PREFIX_TOKEN, using(JsonLexer))
             ),
             # JSON body.

--- a/httpie/output/lexers/json.py
+++ b/httpie/output/lexers/json.py
@@ -5,6 +5,7 @@ from pygments.lexers.data import JsonLexer
 from pygments.token import Token
 
 PREFIX_TOKEN = Token.Error
+# Original prefix regex - matches anything except {, [, "
 PREFIX_REGEX = r'[^{\["]+'
 
 
@@ -20,8 +21,11 @@ class EnhancedJsonLexer(RegexLexer):
     tokens = {
         'root': [
             # Eventual non-JSON data prefix followed by actual JSON body.
+            # Handle numbers specially: match prefix that doesn't end with digits
+            # when a number follows (to avoid matching numbers in prefixes like while(1);)
             (
-                fr'({PREFIX_REGEX})' + r'((?:[{\["]|true|false|null|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?).*)',
+                r'([^{\["]+?)(?=[{\["tfn]|(?<![a-zA-Z0-9)])-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?(?![;)\]}]))'
+                + r'((?:[{\["]|true|false|null|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?).*)',
                 bygroups(PREFIX_TOKEN, using(JsonLexer))
             ),
             # JSON body.

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -28,12 +28,13 @@ TEST_JSON_XXSI_PREFIXES = [
     '}',
 ]
 TEST_JSON_VALUES = [
-    # FIXME: missing int & float
     {},
     {'a': 0, 'b': 0},
     [],
     ['a', 'b'],
     'foo',
+    42,
+    3.14,
     True,
     False,
     None,


### PR DESCRIPTION
- Add 42 and 3.14 to TEST_JSON_VALUES to test numeric JSON parsing
- Fix EnhancedJsonLexer regex to handle prefixes before numeric JSON values
- Resolves FIXME comment about missing int & float test coverage