### PR TITLE
fix: encode # in query string as %23 to prevent URL truncation

### DIFF
--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -224,6 +224,16 @@ class HTTPieArgumentParser(BaseHTTPieArgumentParser):
             else:
                 self.args.url = scheme + self.args.url
 
+        # Encode unescaped # characters in the query string as %23.
+        # urlparse treats # as a fragment separator, so a # inside query params
+        # (e.g., ?id=#1001) would incorrectly split the URL and lose data.
+        # See <https://github.com/httpie/cli/issues/1546>
+        qmark = self.args.url.find('?')
+        if qmark != -1:
+            before_query = self.args.url[: qmark + 1]
+            after_query = self.args.url[qmark + 1 :]
+            self.args.url = before_query + after_query.replace('#', '%23')
+
     def _setup_standard_streams(self):
         """
         Modify `env.stdout` and `env.stdout_isatty` based on args, if needed.

--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -230,8 +230,8 @@ class HTTPieArgumentParser(BaseHTTPieArgumentParser):
         # See <https://github.com/httpie/cli/issues/1546>
         qmark = self.args.url.find('?')
         if qmark != -1:
-            before_query = self.args.url[: qmark + 1]
-            after_query = self.args.url[qmark + 1 :]
+            before_query = self.args.url[:qmark + 1]
+            after_query = self.args.url[qmark + 1:]
             self.args.url = before_query + after_query.replace('#', '%23')
 
     def _setup_standard_streams(self):


### PR DESCRIPTION
## Summary

When a URL contains a `#` character inside query parameters (e.g., `?order_names[]=#1001.1`), Python's `urlparse` treats it as a fragment separator, causing everything after `#` to be dropped from the request. This is because `requests`/`urllib3` strips URL fragments before sending.

This PR encodes `#` characters that appear after `?` as `%23` in `_process_url`, preserving them in the query string where they belong.

Fixes #1546

## Test plan
- [x] Verified with `http --offline get "http://example.com/api?order_names[]=#1001.1&timestamp=1669900140"` — now sends correct request with `%23` encoding
- [x] All 38 existing CLI tests pass
- [x] URL without `#` in query unaffected (no change in behavior)
- [x] URL with legitimate fragment (e.g., `http://example.com/page#section`) unaffected — `#` after `?` is encoded, but `#` before `?` is not