### PR TITLE
fix: remove unused import and unnecessary f-string prefix

### DIFF
--- a/extras/packaging/linux/scripts/hooks/hook-pip.py
+++ b/extras/packaging/linux/scripts/hooks/hook-pip.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from PyInstaller.utils.hooks import collect_all
 
 def hook(hook_api):

--- a/extras/scripts/generate_man_pages.py
+++ b/extras/scripts/generate_man_pages.py
@@ -116,7 +116,7 @@ def _escape_and_dedent(text: str) -> str:
 def to_man_page(program_name: str, spec: ParserSpec, *, is_top_level_cmd: bool = False) -> str:
     builder = ManPageBuilder()
     builder.add_comment(
-        f"This file is auto-generated from the parser declaration "
+        "This file is auto-generated from the parser declaration "
         + (f"in {Path(spec.source_file).relative_to(PROJECT_ROOT)} " if spec.source_file else "")
         + f"by {Path(__file__).relative_to(PROJECT_ROOT)}."
     )


### PR DESCRIPTION
## Summary

- Remove unused `Path` import in `extras/packaging/linux/scripts/hooks/hook-pip.py` (ruff F401)
- Remove `f` prefix from string with no `{...}` placeholders in `extras/scripts/generate_man_pages.py` (ruff F541)

2 files, 2 lines. Safe, mechanical lint fixes — zero behavior change.

Found by [HUMMBL Arbiter](https://hummbl.io/audit) — deterministic code quality scoring for Python repositories.