### PR TITLE
fix: pin charset-normalizer to <3 to fix Big5 encoding detection (#1628)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ project_urls =
 packages = find:
 install_requires =
     pip
-    charset_normalizer>=2.0.0
+    charset_normalizer>=2.0.0,<3.0.0
     defusedxml>=0.6.0
     requests[socks] >=2.22.0
     Pygments>=2.5.2


### PR DESCRIPTION
charset-normalizer 3.x changed its detection algorithm, causing Big5-encoded Chinese text to be misdetected as johab (Korean). This breaks the test_terminal_output_response_charset_detection and test_terminal_output_request_charset_detection tests for Big5.

Pin to charset-normalizer>=2.0.0,<3.0.0 until the upstream ranking regression is resolved.

Fixes #1628