### PR TITLE
feat: add default_timeout support to config

### DIFF
--- a/httpie/client.py
+++ b/httpie/client.py
@@ -63,7 +63,7 @@ def collect_messages(
         base_headers=httpie_session_headers,
         request_body_read_callback=request_body_read_callback
     )
-    send_kwargs = make_send_kwargs(args)
+    send_kwargs = make_send_kwargs(args, env)
     send_kwargs_mergeable_from_env = make_send_kwargs_mergeable_from_env(args)
     requests_session = build_requests_session(
         ssl_version=args.ssl_version,
@@ -278,9 +278,12 @@ def make_default_headers(args: argparse.Namespace) -> HTTPHeadersDict:
     return default_headers
 
 
-def make_send_kwargs(args: argparse.Namespace) -> dict:
+def make_send_kwargs(args: argparse.Namespace, env: Environment = None) -> dict:
+    timeout = args.timeout or None
+    if timeout is None and env is not None and env.config.default_timeout:
+        timeout = env.config.default_timeout
     return {
-        'timeout': args.timeout or None,
+        'timeout': timeout,
         'allow_redirects': False,
     }
 
@@ -339,7 +342,7 @@ def make_request_kwargs(
     if (args.json or auto_json) and isinstance(data, dict):
         data = json_dict_to_request_body(data)
 
-   # Finalize headers.
+    # Finalize headers.
     headers = make_default_headers(args)
     if base_headers:
         headers.update(base_headers)

--- a/httpie/client.py
+++ b/httpie/client.py
@@ -339,10 +339,13 @@ def make_request_kwargs(
     if (args.json or auto_json) and isinstance(data, dict):
         data = json_dict_to_request_body(data)
 
-    # Finalize headers.
+   # Finalize headers.
     headers = make_default_headers(args)
     if base_headers:
         headers.update(base_headers)
+    # Apply default headers from config (can be overridden by user)
+    if env.config.default_headers:
+        headers.update(env.config.default_headers)
     headers.update(args.headers)
     if args.offline and args.chunked and 'Transfer-Encoding' not in headers:
         # When online, we let requests set the header instead to be able more

--- a/httpie/config.py
+++ b/httpie/config.py
@@ -138,7 +138,8 @@ class Config(BaseConfigDict):
     FILENAME = 'config.json'
     DEFAULTS = {
         'default_options': [],
-        'default_headers': {}
+        'default_headers': {},
+        'default_timeout': None
     }
 
     def __init__(self, directory: Union[str, Path] = DEFAULT_CONFIG_DIR):
@@ -153,6 +154,10 @@ class Config(BaseConfigDict):
     @property
     def default_headers(self) -> dict:
         return self['default_headers']
+
+    @property
+    def default_timeout(self):
+        return self['default_timeout']
 
     def _configured_path(self, config_option: str, default: str) -> None:
         return Path(

--- a/httpie/config.py
+++ b/httpie/config.py
@@ -137,7 +137,8 @@ class BaseConfigDict(dict):
 class Config(BaseConfigDict):
     FILENAME = 'config.json'
     DEFAULTS = {
-        'default_options': []
+        'default_options': [],
+        'default_headers': {}
     }
 
     def __init__(self, directory: Union[str, Path] = DEFAULT_CONFIG_DIR):
@@ -148,6 +149,10 @@ class Config(BaseConfigDict):
     @property
     def default_options(self) -> list:
         return self['default_options']
+
+    @property
+    def default_headers(self) -> dict:
+        return self['default_headers']
 
     def _configured_path(self, config_option: str, default: str) -> None:
         return Path(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -102,3 +102,20 @@ def test_custom_config_dir(monkeypatch: MonkeyPatch, tmp_path: Path):
 def test_windows_config_dir(monkeypatch: MonkeyPatch):
     monkeypatch.delenv(ENV_HTTPIE_CONFIG_DIR, raising=False)
     assert get_default_config_dir() == DEFAULT_WINDOWS_CONFIG_DIR
+
+def test_default_headers(httpbin):
+    env = MockEnvironment()
+    env.config['default_headers'] = {'X-Custom-Header': 'test-value'}
+    env.config.save()
+    r = http(httpbin + '/headers', env=env)
+    assert HTTP_OK in r
+    assert r.json['headers']['X-Custom-Header'] == 'test-value'
+
+
+def test_default_headers_overridable(httpbin):
+    env = MockEnvironment()
+    env.config['default_headers'] = {'X-Custom-Header': 'default-value'}
+    env.config.save()
+    r = http(httpbin + '/headers', 'X-Custom-Header:override-value', env=env)
+    assert HTTP_OK in r
+    assert r.json['headers']['X-Custom-Header'] == 'override-value'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -103,6 +103,7 @@ def test_windows_config_dir(monkeypatch: MonkeyPatch):
     monkeypatch.delenv(ENV_HTTPIE_CONFIG_DIR, raising=False)
     assert get_default_config_dir() == DEFAULT_WINDOWS_CONFIG_DIR
 
+
 def test_default_headers(httpbin):
     env = MockEnvironment()
     env.config['default_headers'] = {'X-Custom-Header': 'test-value'}
@@ -119,6 +120,7 @@ def test_default_headers_overridable(httpbin):
     r = http(httpbin + '/headers', 'X-Custom-Header:override-value', env=env)
     assert HTTP_OK in r
     assert r.json['headers']['X-Custom-Header'] == 'override-value'
+
 
 def test_default_timeout(httpbin):
     env = MockEnvironment()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -119,3 +119,17 @@ def test_default_headers_overridable(httpbin):
     r = http(httpbin + '/headers', 'X-Custom-Header:override-value', env=env)
     assert HTTP_OK in r
     assert r.json['headers']['X-Custom-Header'] == 'override-value'
+
+def test_default_timeout(httpbin):
+    env = MockEnvironment()
+    env.config['default_timeout'] = 30
+    env.config.save()
+    assert env.config.default_timeout == 30
+
+
+def test_default_timeout_overridable(httpbin):
+    env = MockEnvironment()
+    env.config['default_timeout'] = 30
+    env.config.save()
+    r = http('--timeout=60', httpbin + '/get', env=env)
+    assert HTTP_OK in r


### PR DESCRIPTION
## What does this PR do?
Adds support for `default_timeout` in HTTPie's config file.
Users can now set a global timeout that applies to all requests automatically.

## How to use it?
Add to your `config.json`:
```json
{
    "default_timeout": 30
}
```

This timeout will apply to all requests unless overridden with `--timeout`.

## Changes
- `httpie/config.py`: Added `default_timeout` to `Config.DEFAULTS` and a new property
- `httpie/client.py`: Applied `default_timeout` from config in `make_send_kwargs`
- `tests/test_config.py`: Added two tests for the new feature