### PR TITLE
skip Content-Length size check when Content-Encoding indicates compression

### DIFF
--- a/httpie/downloads.py
+++ b/httpie/downloads.py
@@ -216,11 +216,21 @@ class Downloader:
         """
         assert not self.status.time_started
 
-        # FIXME: some servers still might sent Content-Encoding: gzip
-        # <https://github.com/httpie/cli/issues/423>
-        try:
-            total_size = int(final_response.headers['Content-Length'])
-        except (KeyError, ValueError, TypeError):
+        # If the server applied a content coding (e.g. ``gzip``), then
+        # ``requests`` auto-decompresses the body in ``iter_content`` while
+        # ``Content-Length`` still reflects the *encoded* size per
+        # RFC 9110 §8.6. Comparing those two numbers would always mark the
+        # download as incomplete, so skip the size tracking in that case.
+        # See <https://github.com/httpie/cli/issues/423>.
+        content_encoding = (
+            final_response.headers.get('Content-Encoding') or 'identity'
+        ).strip().lower()
+        if content_encoding == 'identity':
+            try:
+                total_size = int(final_response.headers['Content-Length'])
+            except (KeyError, ValueError, TypeError):
+                total_size = None
+        else:
             total_size = None
 
         if not self._output_file:

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -147,6 +147,53 @@ class TestDownloads:
             downloader.finish()
             assert not downloader.interrupted
 
+    def test_download_with_Content_Encoding_skips_size_check(self, mock_env, httpbin_both):
+        # When the server applies a content coding, ``requests`` auto-decompresses
+        # the body but Content-Length still reflects the encoded size per
+        # RFC 9110 §8.6. The downloader must skip the size comparison in that
+        # case so a fully-received, encoded payload isn't reported as an
+        # "Incomplete download".
+        # <https://github.com/httpie/cli/issues/423>
+        with open(os.devnull, 'w') as devnull:
+            for content_encoding in ('gzip', 'br', 'deflate'):
+                downloader = Downloader(mock_env, output_file=devnull)
+                downloader.start(
+                    initial_url='/',
+                    final_response=Response(
+                        url=httpbin_both.url + '/',
+                        headers={
+                            'Content-Length': 10,
+                            'Content-Encoding': content_encoding,
+                        },
+                    ),
+                )
+                # Decompressed stream ends up much larger than the encoded size.
+                downloader.chunk_downloaded(b'1234567890' * 1000)
+                downloader.finish()
+                assert not downloader.interrupted, (
+                    f'Content-Encoding={content_encoding!r} should bypass '
+                    f'the size comparison; got interrupted=True.'
+                )
+
+    def test_download_with_Content_Encoding_uppercase_or_padded(self, mock_env, httpbin_both):
+        # Header values come back with arbitrary casing and surrounding whitespace;
+        # the downloader must recognise those as content codings too.
+        with open(os.devnull, 'w') as devnull:
+            downloader = Downloader(mock_env, output_file=devnull)
+            downloader.start(
+                initial_url='/',
+                final_response=Response(
+                    url=httpbin_both.url + '/',
+                    headers={
+                        'Content-Length': 10,
+                        'Content-Encoding': '  GZIP  ',
+                    },
+                ),
+            )
+            downloader.chunk_downloaded(b'1234567890' * 1000)
+            downloader.finish()
+            assert not downloader.interrupted
+
     def test_download_no_Content_Length(self, mock_env, httpbin_both):
         with open(os.devnull, 'w') as devnull:
             downloader = Downloader(mock_env, output_file=devnull)


### PR DESCRIPTION
When the server returns `Content-Encoding: gzip` even though the request asks for `Accept-Encoding: identity`, the underlying `requests` session still transparently decompresses the body inside `iter_content()`. Per RFC 9110 §8.6 the `Content-Length` header still describes the *encoded* payload size, but `Downloader.chunk_downloaded()` accumulates the *decoded* bytes produced by `requests`. `Downloader.interrupted` then compared the encoded `total_size` to the decoded byte count and always flagged the download as incomplete, even when every byte was received successfully.

This shows up in practice as the spurious `http: error: Incomplete download: size=5084527; downloaded=42846965` message in #1642, and the existing `# FIXME: some servers still might sent Content-Encoding: gzip` in `httpie/downloads.py` was the only acknowledgement of the gap.

The fix is to skip the size tracking whenever the response carries a non-identity `Content-Encoding`. `total_size` is set to `None` (the same fallback used for a missing `Content-Length`), which already lets `interrupted` short-circuit and lets the progress reporter fall back to an indeterminate spinner — matching the behaviour of `curl` and `wget` for compressed downloads.

Changes:
- `httpie/downloads.py`: read `Content-Encoding`, normalise it (strip + lower), and treat anything other than `identity` as "size unknown" for the duration of the download.
- `tests/test_downloads.py`: new regression tests covering `gzip`, `deflate`, `br`, mixed-case header values, and surrounding whitespace.

Fixes #1642 (and the underlying gap noted by the existing `# FIXME` comment that referenced issue #423).