### PR TITLE
docs: add pipx installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,19 @@ Please note we recently accidentally made this repo private for a moment, and Gi
 
 ## Getting started
 
+### Alternative installation (pipx)
+
+For isolated installations, you can use pipx:
+
+```bash
+pip install pipx
+pipx install httpie
+```
+
 - [Installation instructions →](https://httpie.io/docs#installation)
 - [Full documentation →](https://httpie.io/docs)
+
+
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -52,20 +52,20 @@ Please note we recently accidentally made this repo private for a moment, and Gi
 
 ## Getting started
 
-### Alternative installation (pipx)
+- [Installation instructions →](https://httpie.io/docs#installation)
+- [Full documentation →](https://httpie.io/docs)
 
-For isolated installations, you can use pipx:
+## Installation (alternative methods)
+
+
+### pipx (recommended for isolated Python CLI tools)
+
+pipx provides isolated environments for Python CLI applications:
 
 ```bash
 pip install pipx
 pipx install httpie
 ```
-
-- [Installation instructions →](https://httpie.io/docs#installation)
-- [Full documentation →](https://httpie.io/docs)
-
-
-
 ## Features
 
 - Expressive and intuitive syntax

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ pipx provides isolated environments for Python CLI applications:
 pip install pipx
 pipx install httpie
 ```
+
 ## Features
 
 - Expressive and intuitive syntax


### PR DESCRIPTION
This PR adds an alternative installation method using `pipx` in the README.

### Changes made:
- Added a new section under "Getting started"
- Included pipx installation commands
- Kept existing installation links unchanged
- No functional or code changes (documentation only)

### Why this change:
pipx provides an isolated environment for installing Python CLI tools, making HTTPie easier to install and manage without affecting system Python packages.

### Checklist:
- [x] Documentation updated
- [x] No breaking changes
- [x] Existing content preserved
- [x] Markdown formatting verified