### PR TITLE
Install fish shell completions via pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,7 @@ include docs/README.md
 
 # <https://github.com/httpie/cli/issues/182>
 recursive-include tests/ *
+
+# Shell completions installed through setup.cfg data_files
+include extras/httpie-completion.fish
+include extras/fish/http.fish

--- a/extras/fish/http.fish
+++ b/extras/fish/http.fish
@@ -1,0 +1,2 @@
+# Fish loads completions by command name; keep the canonical definitions in one file.
+source (dirname (status --current-filename))/httpie-completion.fish

--- a/setup.cfg
+++ b/setup.cfg
@@ -108,3 +108,6 @@ share/man/man1 =
     extras/man/http.1
     extras/man/https.1
     extras/man/httpie.1
+share/fish/vendor_completions.d =
+    extras/httpie-completion.fish
+    extras/fish/http.fish


### PR DESCRIPTION
## Summary

Fixes #912.

Install HTTPie's existing Fish completions through Python wheels and source distributions, so Fish discovers completions for the `http` command without downstream package-specific copying.

## Changes

- Add `share/fish/vendor_completions.d` to `setup.cfg` data files
- Install the canonical `extras/httpie-completion.fish` unchanged
- Add a command-named `http.fish` loader that sources the canonical definitions, avoiding a duplicated completion script
- Include both files in the source distribution manifest

## Test plan

- [x] `python -m build --sdist --wheel`
- [x] Wheel contains `share/fish/vendor_completions.d/http.fish`
- [x] Wheel contains `share/fish/vendor_completions.d/httpie-completion.fish`
- [x] Source distribution contains both source files