### PR TITLE
Fix Windows guard in man page availability check

### DIFF
--- a/httpie/output/ui/man_pages.py
+++ b/httpie/output/ui/man_pages.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import os
+import sys
 from httpie.context import Environment
 
 
@@ -18,7 +19,7 @@ def is_available(program: str) -> bool:
     Check whether `program`'s man pages are available on this system.
 
     """
-    if NO_MAN_PAGES or os.system == 'nt':
+    if NO_MAN_PAGES or sys.platform == 'win32':
         return False
     try:
         process = subprocess.run(

--- a/tests/test_man_pages.py
+++ b/tests/test_man_pages.py
@@ -1,0 +1,48 @@
+from httpie.output.ui.man_pages import is_available
+
+
+def test_is_available_returns_false_on_windows(monkeypatch):
+    monkeypatch.setattr("httpie.output.ui.man_pages.sys.platform", "win32")
+    assert is_available("http") is False
+
+
+def test_is_available_honors_no_man_pages_env(monkeypatch):
+    monkeypatch.setattr("httpie.output.ui.man_pages.NO_MAN_PAGES", True)
+    monkeypatch.setattr("httpie.output.ui.man_pages.sys.platform", "linux")
+    assert is_available("http") is False
+
+
+def test_is_available_returns_true_when_man_succeeds(monkeypatch):
+    monkeypatch.setattr("httpie.output.ui.man_pages.sys.platform", "linux")
+
+    class CompletedProcess:
+        returncode = 0
+
+    monkeypatch.setattr(
+        "httpie.output.ui.man_pages.subprocess.run",
+        lambda *args, **kwargs: CompletedProcess(),
+    )
+    assert is_available("http") is True
+
+
+def test_is_available_returns_false_when_man_fails(monkeypatch):
+    monkeypatch.setattr("httpie.output.ui.man_pages.sys.platform", "linux")
+
+    class CompletedProcess:
+        returncode = 1
+
+    monkeypatch.setattr(
+        "httpie.output.ui.man_pages.subprocess.run",
+        lambda *args, **kwargs: CompletedProcess(),
+    )
+    assert is_available("http") is False
+
+
+def test_is_available_returns_false_when_man_raises(monkeypatch):
+    monkeypatch.setattr("httpie.output.ui.man_pages.sys.platform", "linux")
+
+    def raise_error(*args, **kwargs):
+        raise OSError("no man")
+
+    monkeypatch.setattr("httpie.output.ui.man_pages.subprocess.run", raise_error)
+    assert is_available("http") is False


### PR DESCRIPTION
## Summary

Fixes #1898.

`is_available()` compared the `os.system` function object to `"nt"`, so the intended Windows short-circuit could never run. Use `sys.platform == "win32"` and cover every return path.

## Test plan

- [x] `pytest tests/test_man_pages.py` — 5 passed
- [x] `flake8 httpie/output/ui/man_pages.py tests/test_man_pages.py`
- [x] Windows guard, `HTTPIE_NO_MAN_PAGES`, successful/failed `man`, and execution-error paths covered
