### PR TITLE
Fix Windows man pages guard (os.system to sys.platform)

### DIFF
--- a/httpie/output/ui/man_pages.py
+++ b/httpie/output/ui/man_pages.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import os
+import sys
 from httpie.context import Environment
 
 
@@ -18,7 +19,7 @@ def is_available(program: str) -> bool:
     Check whether `program`'s man pages are available on this system.
 
     """
-    if NO_MAN_PAGES or os.system == 'nt':
+    if NO_MAN_PAGES or sys.platform == 'win32':
         return False
     try:
         process = subprocess.run(

--- a/httpie/output/ui/man_pages.py
+++ b/httpie/output/ui/man_pages.py
@@ -1,7 +1,7 @@
 """Logic for checking and displaying man pages."""
 
-import subprocess
 import os
+import subprocess
 import sys
 from httpie.context import Environment
 

--- a/tests/test_man_pages.py
+++ b/tests/test_man_pages.py
@@ -1,0 +1,12 @@
+from unittest.mock import Mock
+
+from httpie.output.ui import man_pages
+
+
+def test_man_pages_are_unavailable_on_windows(monkeypatch):
+    run = Mock()
+    monkeypatch.setattr(man_pages.sys, 'platform', 'win32')
+    monkeypatch.setattr(man_pages.subprocess, 'run', run)
+
+    assert man_pages.is_available('http') is False
+    run.assert_not_called()


### PR DESCRIPTION
Fixes #1898

## Problem

`os.system` is a function object, so comparing it with `"nt"` is always false. HTTPie can therefore attempt to invoke `man` on Windows.

## Change

- use `sys.platform == "win32"` for the platform guard
- return before spawning a subprocess on Windows
- add a regression test proving `subprocess.run` is not called

## Validation

- focused Windows guard regression: pass
- code-style check: pass
