### PR TITLE
Fix test_lazy_choices_help failing on Python 3.14

### DIFF
--- a/httpie/cli/utils.py
+++ b/httpie/cli/utils.py
@@ -41,8 +41,10 @@ class LazyChoices(argparse.Action, Generic[T]):
         self.sort = sort
         self.cache = cache
         self.isolation_mode = isolation_mode
-        self._help: Optional[str] = None
         self._obj: Optional[Iterable[T]] = None
+        # Initialize before super().__init__ to prevent argparse
+        # from triggering getter() during __init__ on Python 3.14
+        self._help = ""
         super().__init__(*args, **kwargs)
         self.choices = self
 

--- a/httpie/cli/utils.py
+++ b/httpie/cli/utils.py
@@ -42,9 +42,12 @@ class LazyChoices(argparse.Action, Generic[T]):
         self.cache = cache
         self.isolation_mode = isolation_mode
         self._obj: Optional[Iterable[T]] = None
-        # Initialize before super().__init__ to prevent argparse
-        # from triggering getter() during __init__ on Python 3.14
-        self._help = ""
+        # Python 3.14 validates an action's help immediately after creating it.
+        # Skip that eager read so lazy help remains lazy until it is rendered.
+        self._skip_initial_help_validation = hasattr(
+            argparse._ActionsContainer,
+            '_check_help'
+        )
         super().__init__(*args, **kwargs)
         self.choices = self
 
@@ -56,7 +59,10 @@ class LazyChoices(argparse.Action, Generic[T]):
         return self._obj
 
     @property
-    def help(self) -> str:
+    def help(self) -> Optional[str]:
+        if self._skip_initial_help_validation:
+            self._skip_initial_help_validation = False
+            return None
         if self._help is None and self.help_formatter is not None:
             self._help = self.help_formatter(
                 self.load(),


### PR DESCRIPTION
Fixes #1641

## Problem

Python 3.14 validates an argparse action's help immediately after constructing the action. That eager read caused `LazyChoices.help` to load choices during parser initialization, breaking the lazy contract.

## Change

- detect argparse's new `_check_help` validation path
- skip exactly the initial eager help read
- preserve normal lazy help generation when help is actually rendered

## Validation

Tested with Python 3.14.6:

- parser initialization does not call the choices getter
- parser initialization does not call the help formatter
- rendering help calls the formatter once with the loaded choices
- code-style check: pass
