### PR TITLE
Add pipx installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Please note we recently accidentally made this repo private for a moment, and Gi
 - [Installation instructions →](https://httpie.io/docs#installation)
 - [Full documentation →](https://httpie.io/docs)
 
+### Quick installation via pipx
+
+```bash
+pipx install httpie
+```
+
 ## Features
 
 - Expressive and intuitive syntax


### PR DESCRIPTION
Fixes #1633

## Summary

Add `pipx` installation guidance to the README so users can install HTTPie in an isolated environment without managing a virtual environment manually.

## Validation

- documentation check: pass
- change is limited to installation documentation
