### PR TITLE
Add pipx install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ Please note we recently accidentally made this repo private for a moment, and Gi
 - [Installation instructions →](https://httpie.io/docs#installation)
 - [Full documentation →](https://httpie.io/docs)
 
+```bash
+# pip
+pip install httpie
+
+# pipx (recommended for CLI tools)
+pipx install httpie
+
+# Homebrew
+brew install httpie
+```
+
 ## Features
 
 - Expressive and intuitive syntax

--- a/httpie/output/ui/man_pages.py
+++ b/httpie/output/ui/man_pages.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import os
+import sys
 from httpie.context import Environment
 
 
@@ -18,7 +19,7 @@ def is_available(program: str) -> bool:
     Check whether `program`'s man pages are available on this system.
 
     """
-    if NO_MAN_PAGES or os.system == 'nt':
+    if NO_MAN_PAGES or sys.platform == 'win32':
         return False
     try:
         process = subprocess.run(


### PR DESCRIPTION
Closes #1905

Added pipx, pip, and Homebrew installation commands to the Getting Started section of README.