### PR TITLE
fix: use 'python' instead of 'py' in chocolatey install script

### DIFF
--- a/docs/packaging/windows-chocolatey/tools/chocolateyinstall.ps1
+++ b/docs/packaging/windows-chocolatey/tools/chocolateyinstall.ps1
@@ -1,2 +1,1 @@
-﻿$ErrorActionPreference = 'Stop';
-py -m pip install $env:ChocolateyPackageName==$env:ChocolateyPackageVersion --disable-pip-version-check
+﻿$ErrorActionPreference = 'Stop';\npython -m pip install $env:ChocolateyPackageName==$env:ChocolateyPackageVersion --disable-pip-version-check\n


### PR DESCRIPTION
Fixes #1617.

The Chocolatey installation script was using the `py` command (the Python Launcher for Windows), which is optional and may not be installed on all systems. Replacing it with `python` ensures the installation works for users who have Python installed but not the launcher.