### PR TITLE
Fix #1623: Decode percent-encoded characters in URL credentials

### DIFF
--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -5,7 +5,7 @@ import re
 import sys
 from argparse import RawDescriptionHelpFormatter
 from textwrap import dedent
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, unquote
 
 from requests.utils import get_netrc_auth
 
@@ -291,6 +291,9 @@ class HTTPieArgumentParser(BaseHTTPieArgumentParser):
                 # Handle http://username:password@hostname/
                 username = url.username
                 password = url.password or ''
+                # Decode percent-encoded characters in username and password
+                username = unquote(username)
+                password = unquote(password)
                 self.args.auth = AuthCredentials(
                     key=username,
                     value=password,
@@ -306,7 +309,7 @@ class HTTPieArgumentParser(BaseHTTPieArgumentParser):
             if (not self.args.ignore_netrc
                     and self.args.auth is None
                     and plugin.netrc_parse):
-                # Only host needed, so it’s OK URL not finalized.
+                # Only host needed, so it's OK URL not finalized.
                 netrc_credentials = get_netrc_auth(self.args.url)
                 if netrc_credentials:
                     self.args.auth = AuthCredentials(
@@ -377,7 +380,7 @@ class HTTPieArgumentParser(BaseHTTPieArgumentParser):
                 invalid.append(option)
 
         if invalid:
-            self.error(f'unrecognized arguments: {" ".join(invalid)}')
+            self.error(f'unrecognized arguments: {"".join(invalid)}')
 
     def _body_from_file(self, fd):
         """Read the data from a file-like object.


### PR DESCRIPTION
This fixes the issue where username/password in URLs were not being decoded before authentication.

For example, a URL like `https://u%40d:***@httpbin.org/basic-auth/u%40d/1%3d2%3f` would use the literal encoded values instead of decoding them to 'u@d' and '1=2?'.

The fix adds decoding of percent-encoded characters in both username and password when they are extracted from URLs in the `_process_auth` method.