### PR TITLE
Fix #1632: fall back to certifi when the OS trust store is empty (macOS)

### DIFF
--- a/httpie/compat.py
+++ b/httpie/compat.py
@@ -1,6 +1,9 @@
+import os
 import sys
 from ssl import SSLContext
 from typing import Any, Optional, Iterable
+
+from requests.adapters import DEFAULT_CA_BUNDLE_PATH
 
 from httpie.cookies import HTTPieCookiePolicy
 from http import cookiejar  # noqa
@@ -103,11 +106,26 @@ def get_dist_name(entry_point: importlib_metadata.EntryPoint) -> Optional[str]:
 
 def ensure_default_certs_loaded(ssl_context: SSLContext) -> None:
     """
-    Workaround for a bug in Requests 2.32.3
+    Load the default CA certificates into the given SSL context.
 
-    See <https://github.com/httpie/cli/issues/1583>
+    Because we always use our own SSL context (to be able to support
+    `--ssl` and `--ciphers`), Requests doesn’t load any CA bundle for us
+    when `--verify=yes` — it assumes a custom context already trusts the
+    default CAs. See <https://github.com/httpie/cli/issues/1583>.
+
+    `SSLContext.load_default_certs()` relies on OpenSSL’s default verify
+    paths, which are empty on some platforms (most notably the python.org
+    macOS builds). In that case we fall back to the `certifi` bundle, which
+    is exactly what Requests itself trusts by default — otherwise HTTPie
+    would end up with an empty trust store and fail to verify any
+    certificate. See <https://github.com/httpie/cli/issues/1632>.
 
     """
-    if hasattr(ssl_context, 'load_default_certs'):
-        if not ssl_context.get_ca_certs():
-            ssl_context.load_default_certs()
+    if not hasattr(ssl_context, 'load_default_certs'):
+        return
+
+    if not ssl_context.get_ca_certs():
+        ssl_context.load_default_certs()
+
+    if not ssl_context.get_ca_certs() and os.path.exists(DEFAULT_CA_BUNDLE_PATH):
+        ssl_context.load_verify_locations(cafile=DEFAULT_CA_BUNDLE_PATH)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,62 @@
+import os
+import ssl
+
+from unittest import mock
+
+from requests.adapters import DEFAULT_CA_BUNDLE_PATH
+
+from httpie.compat import ensure_default_certs_loaded
+
+
+def _empty_trust_store_env(tmp_path):
+    """Point OpenSSL’s default verify paths at an empty location.
+
+    This emulates the python.org macOS builds, where the OS trust store is
+    not reachable through OpenSSL’s defaults.
+    """
+    return {
+        'SSL_CERT_FILE': str(tmp_path / '__no_such_ca_bundle__.pem'),
+        'SSL_CERT_DIR': str(tmp_path),
+    }
+
+
+def test_ensure_default_certs_loaded_from_os_trust_store():
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ensure_default_certs_loaded(ssl_context)
+    assert ssl_context.get_ca_certs()
+
+
+def test_ensure_default_certs_loaded_falls_back_to_certifi(tmp_path):
+    """<https://github.com/httpie/cli/issues/1632>"""
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    with mock.patch.dict(os.environ, _empty_trust_store_env(tmp_path)):
+        ssl_context.load_default_certs()
+        assert not ssl_context.get_ca_certs(), (
+            'precondition: the OS trust store must be empty for this test'
+        )
+        ensure_default_certs_loaded(ssl_context)
+    assert ssl_context.get_ca_certs(), (
+        'the certifi bundle should have been loaded as a fallback'
+    )
+
+
+def test_ensure_default_certs_loaded_keeps_already_loaded_certs():
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ssl_context.load_verify_locations(cafile=DEFAULT_CA_BUNDLE_PATH)
+    already_loaded = ssl_context.get_ca_certs()
+    with mock.patch.object(ssl_context, 'load_default_certs') as load_default_certs:
+        ensure_default_certs_loaded(ssl_context)
+        load_default_certs.assert_not_called()
+    assert ssl_context.get_ca_certs() == already_loaded
+
+
+def test_ensure_default_certs_loaded_without_any_bundle_available(tmp_path):
+    """A missing certifi bundle must not turn into a hard error."""
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    with mock.patch.dict(os.environ, _empty_trust_store_env(tmp_path)), \
+            mock.patch(
+                'httpie.compat.DEFAULT_CA_BUNDLE_PATH',
+                str(tmp_path / '__no_such_certifi_bundle__.pem'),
+            ):
+        ensure_default_certs_loaded(ssl_context)
+    assert not ssl_context.get_ca_certs()


### PR DESCRIPTION
Fixes #1632

## Problem

On the python.org macOS builds, every HTTPS request fails out of the box:

```
https: error: SSLError: ... [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
unable to get local issuer certificate
```

…while `requests` in the *same* virtualenv works fine, and `https --verify "$(python -m certifi)" ...` also works. So it's not a missing `certifi` — HTTPie just isn't finding a trust store.

## Root cause

HTTPie always installs its own `SSLContext` (`HTTPieHTTPSAdapter._create_ssl_context`, needed to support `--ssl` / `--ciphers`). Requests deliberately loads **no** CA bundle when `verify is True` and a custom context is in play — see `HTTPAdapter.cert_verify`:

> Only load the CA certificates if 'verify' is a string indicating the CA bundle to use. Otherwise, if verify is a boolean, we don't load anything since the connection will be using a context with the default certificates already loaded

So loading the defaults is entirely on us, via `compat.ensure_default_certs_loaded()` (added for #1583). That function relied solely on `SSLContext.load_default_certs()`, which uses **OpenSSL's default verify paths**. On the python.org macOS builds those paths point at a location OpenSSL can't use, so `load_default_certs()` is a no-op and the context is left with an *empty* trust store — hence "unable to get local issuer certificate" for every host. `requests` doesn't hit this because its own default is `certifi` (`DEFAULT_CA_BUNDLE_PATH`), not the OpenSSL default paths.

## Fix

If the OS trust store yields no certificates, fall back to `requests.adapters.DEFAULT_CA_BUNDLE_PATH` (the certifi bundle) — i.e. trust exactly what Requests itself trusts by default:

```python
if not ssl_context.get_ca_certs():
    ssl_context.load_default_certs()

if not ssl_context.get_ca_certs() and os.path.exists(DEFAULT_CA_BUNDLE_PATH):
    ssl_context.load_verify_locations(cafile=DEFAULT_CA_BUNDLE_PATH)
```

Deliberately conservative:
- Platforms where the OS trust store *does* work (Linux, Windows, Homebrew Python) are unchanged — the fallback never runs.
- The system store still wins when present; certifi is only a last resort.
- No new dependency: `certifi` is already a hard dependency of `requests`, and `DEFAULT_CA_BUNDLE_PATH` is what Requests uses itself.
- A missing bundle is skipped rather than raising, so this can't turn a verification failure into a crash.
- `--verify=no` and `--verify=<path>` paths are untouched.

## Verification

Reproduced and verified in a sandbox with `httpie 3.2.4` + `requests 2.32.3`, forcing OpenSSL's default verify paths to an empty location to emulate the macOS build (`SSL_CERT_FILE`/`SSL_CERT_DIR` → empty dir), with `certifi` installed:

| | before | after |
|---|---|---|
| `requests.get('https://example.com')` | 200 | 200 |
| `python -m httpie GET https://example.com` | **exit 1, CERTIFICATE_VERIFY_FAILED** | **exit 0, `HTTP/1.1 200 OK`** |

Adapter-level check after the fix, with the OS store empty: `HTTPieHTTPSAdapter._create_ssl_context(verify=True)` → 121 CA certs loaded, `verify_mode=CERT_REQUIRED`; `verify=False` → `CERT_NONE` (unchanged). `--verify=no` and a normal environment with a working OS store both still return `200 OK`.

`tests/test_compat.py` adds 4 tests, incl. the regression case and edge cases (already-loaded certs are not reloaded; a missing certifi bundle doesn't raise). `test_ensure_default_certs_loaded_falls_back_to_certifi` **fails against the previous implementation** (asserts on an empty `get_ca_certs()`) and passes with this change — confirmed by reverting the function and re-running: `1 failed, 3 passed` → `4 passed`.

`flake8` clean on both changed files.
